### PR TITLE
EAHW-2221-Add-SonarCloud: update drone script with sonar cloud command

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ steps:
 - name: sonar branch
   image: maven:3.8-openjdk-17
   depends_on:
-    - test
+  - test
   environment:
     SONAR_HOST:
       from_secret: sonar_cloud_host

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,12 +25,11 @@ steps:
   - test
   environment:
     SONAR_HOST:
-      from_secret: sonar_host
+      from_secret: sonar_cloud_host
     SONAR_TOKEN:
-      from_secret: sonar_token
+      from_secret: sonar_cloud_token
   commands:
-  - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -DprojectKeySuffix=$${projectSuffix}
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,7 +47,7 @@ steps:
       from_secret: sonar_cloud_token
   commands:
     - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
-    - mvn clean verify sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
+    - mvn -s ./jparest_settings.xml -f pom.xml clean verify sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,9 +25,9 @@ steps:
   - test
   environment:
     SONAR_HOST:
-      from_secret: sonar_host
+      from_secret: sonar_cloud_host
     SONAR_TOKEN:
-      from_secret: sonar_token
+      from_secret: sonar_cloud_token
   commands:
   - "branchName=$(echo $DRONE_BRANCH)"
   - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName}

--- a/.drone.yml
+++ b/.drone.yml
@@ -45,13 +45,13 @@ steps:
       from_secret: sonar_cloud_host
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
-    commands:
-    - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
-    - mvn sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=6d6fd8074b1729accb9f98cd3930979abc5e2512 -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
-    when:
-      event:
-        exclude:
-          - pull_request
+  commands:
+  - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
+  - mvn sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=6d6fd8074b1729accb9f98cd3930979abc5e2512 -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
+  when:
+    event:
+      exclude:
+      - pull_request
 
 - name: publish
   image: maven:3.8-openjdk-17

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
   commands:
   - mvn clean install
 
-- name: sonar
+- name: sonar main
   image: maven:3.8-openjdk-17
   depends_on:
   - test
@@ -31,9 +31,27 @@ steps:
   commands:
   - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest
   when:
+    branch: main
     event:
       exclude:
       - pull_request
+
+- name: sonar branch
+  image: maven:3.8-openjdk-17
+  depends_on:
+    - test
+  environment:
+    SONAR_HOST:
+      from_secret: sonar_cloud_host
+    SONAR_TOKEN:
+      from_secret: sonar_cloud_token
+    commands:
+    - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
+    - mvn sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=6d6fd8074b1729accb9f98cd3930979abc5e2512 -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
+    when:
+      event:
+        exclude:
+          - pull_request
 
 - name: publish
   image: maven:3.8-openjdk-17
@@ -52,7 +70,7 @@ steps:
       exclude:
       - pull_request
 
-- name: Git Tag
+- name: git tag
   image: alpine/git
   depends_on:
     - publish

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,7 +47,7 @@ steps:
       from_secret: sonar_cloud_token
   commands:
   - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
-  - mvn sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=6d6fd8074b1729accb9f98cd3930979abc5e2512 -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
   commands:
   - mvn clean install
 
-- name: sonar main
+- name: sonar
   image: maven:3.8-openjdk-17
   depends_on:
     - test
@@ -31,27 +31,12 @@ steps:
   commands:
     - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest
   when:
-    branch: main
+    branch:
+      - main
+      - EAHW-*
     event:
       exclude:
       - pull_request
-
-- name: sonar branch
-  image: maven:3.8-openjdk-17
-  depends_on:
-    - test
-  environment:
-    SONAR_HOST:
-      from_secret: sonar_cloud_host
-    SONAR_TOKEN:
-      from_secret: sonar_cloud_token
-  commands:
-    - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
-    - mvn -s ./jparest_settings.xml -f pom.xml clean verify sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
-  when:
-    event:
-      exclude:
-        - pull_request
 
 - name: publish
   image: maven:3.8-openjdk-17

--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ steps:
     - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && snapshotSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
     - version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
     - mvn versions:set -DnewVersion=$version$${snapshotSuffix}-SNAPSHOT -f pom.xml
-    - mvn -s ./jparest_settings.xml -f pom.xml install -B org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -DskipTests
+    - mvn -s ./jparest_settings.xml -f pom.xml install -B org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -DsnapshotSuffix=$${snapshotSuffix}-SNAPSHOT -DskipTests
   when:
     branch:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,36 +22,36 @@ steps:
 - name: sonar main
   image: maven:3.8-openjdk-17
   depends_on:
-  - test
+    - test
   environment:
     SONAR_HOST:
       from_secret: sonar_cloud_host
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest
+    - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest
   when:
     branch: main
     event:
       exclude:
       - pull_request
 
-- name: sonar branch
+- name: sonar main
   image: maven:3.8-openjdk-17
   depends_on:
-  - test
+    - test
   environment:
     SONAR_HOST:
       from_secret: sonar_cloud_host
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
-  - mvn clean verify sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
+    - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
+    - mvn clean verify sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
   when:
     event:
       exclude:
-      - pull_request
+        - pull_request
 
 - name: publish
   image: maven:3.8-openjdk-17

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,7 @@ steps:
       exclude:
       - pull_request
 
-- name: sonar main
+- name: sonar branch
   image: maven:3.8-openjdk-17
   depends_on:
     - test

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,15 +22,15 @@ steps:
 - name: sonar
   image: maven:3.8-openjdk-17
   depends_on:
-    - test
+  - test
   environment:
     SONAR_HOST:
-      from_secret: sonar_cloud_host
+      from_secret: sonar_host
     SONAR_TOKEN:
-      from_secret: sonar_cloud_token
+      from_secret: sonar_token
   commands:
-    - "branchName=$(echo $DRONE_BRANCH)"
-    - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName}
+  - "branchName=$(echo $DRONE_BRANCH)"
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName}
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,11 +29,9 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-    - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest
+    - "branchName=$(echo $DRONE_BRANCH)"
+    - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName}
   when:
-    branch:
-      - main
-      - EAHW-*
     event:
       exclude:
       - pull_request
@@ -82,7 +80,7 @@ steps:
     - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && snapshotSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
     - version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
     - mvn versions:set -DnewVersion=$version$${snapshotSuffix}-SNAPSHOT -f pom.xml
-    - mvn -s ./jparest_settings.xml -f pom.xml install -B org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -DsnapshotSuffix=$${snapshotSuffix}-SNAPSHOT -DskipTests
+    - mvn -s ./jparest_settings.xml -f pom.xml install -B org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy -DskipTests
   when:
     branch:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -29,8 +29,7 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - "branchName=$(echo $DRONE_BRANCH)"
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName}
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$DRONE_BRANCH
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,7 +47,7 @@ steps:
       from_secret: sonar_cloud_token
   commands:
   - "BRANCH=$(echo $DRONE_BRANCH | tr '[:lower:]' '[:upper:]') && [[ $BRANCH =~ (EAHW-[0-9]*) ]] && projectSuffix=$${match/#E/-E}$${BASH_REMATCH/#E/-E}"
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
+  - mvn clean verify sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.pullrequest.branch=$${projectSuffix} -Dsonar.pullrequest.key=${DRONE_COMMIT}
   when:
     event:
       exclude:

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.0.2</version>
+		<version>0.0.4</version>
 	</parent>
 
 	<properties>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.2</version>
+        <version>0.0.4</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jparest_settings.xml
+++ b/jparest_settings.xml
@@ -14,9 +14,4 @@
             </configuration>
         </server>
     </servers>
-    <pluginGroups>
-        <pluginGroup>
-            org.sonarsource.scanner.maven
-        </pluginGroup>
-    </pluginGroups>
 </settings>

--- a/jparest_settings.xml
+++ b/jparest_settings.xml
@@ -14,4 +14,9 @@
             </configuration>
         </server>
     </servers>
+    <pluginGroups>
+        <pluginGroup>
+            org.sonarsource.scanner.maven
+        </pluginGroup>
+    </pluginGroups>
 </settings>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <project.version>0.0.1${snapshotSuffix}</project.version>
+        <project.version>0.0.2${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <project.version>0.0.3${snapshotSuffix}</project.version>
+        <project.version>0.0.4${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
               </execution>
             </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>3.9.1.2184</version>
+            </plugin>
         </plugins>
       </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,6 @@
               </execution>
             </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonarsource.scanner.maven</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-                <version>3.9.1.2184</version>
-            </plugin>
         </plugins>
       </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,10 +18,7 @@
         <!-- JaCoCo Properties -->
         <jacoco.version>0.8.7</jacoco.version>
         <!-- Sonar Properties -->
-        <projectKeySuffix></projectKeySuffix>
-        <sonar.projectKey>callisto-JpaRest${projectKeySuffix}</sonar.projectKey>
-        <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
-        <sonar.projectName>callisto-JpaRest${projectKeySuffix}</sonar.projectName>
+        <branchName></branchName>
         <sonar.language>java</sonar.language>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,10 @@
               </execution>
             </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonarsource.scanner.maven</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+            </plugin>
         </plugins>
       </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,6 @@
               </execution>
             </executions>
             </plugin>
-            <plugin>
-                <groupId>org.sonarsource.scanner.maven</groupId>
-                <artifactId>sonar-maven-plugin</artifactId>
-            </plugin>
         </plugins>
       </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
     <packaging>pom</packaging>
 
     <properties>
-        <project.version>0.0.4${snapshotSuffix}</project.version>
+        <project.version>0.0.3${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -18,7 +18,6 @@
         <!-- JaCoCo Properties -->
         <jacoco.version>0.8.7</jacoco.version>
         <!-- Sonar Properties -->
-        <branchName></branchName>
         <sonar.language>java</sonar.language>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
     </properties>


### PR DESCRIPTION
This PR contains the changes required to move away from Sonarqube and start using Sonarcloud. The secrets within drone will be updated to point to sonarqube. 

The branch name property has been introduced to allow for a blank entry in the sonar.branch.name property. In order to keep the analysis on the master branch working.

Some tidy up has also been implemented. 