### PR TITLE
eahw-2221-update-branch-scan: add branch name step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,17 @@ steps:
   commands:
   - mvn clean install
 
+- name: branch name
+  image: maven:3.8-openjdk-17
+  depends_on:
+    - test
+  commands:
+    - "branchName=$(echo $DRONE_BRANCH)"
+  when:
+    branch:
+      exclude:
+        - main
+
 - name: sonar
   image: maven:3.8-openjdk-17
   depends_on:
@@ -29,7 +40,7 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$DRONE_BRANCH
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName}
   when:
     event:
       exclude:
@@ -84,44 +95,6 @@ steps:
     branch:
       exclude:
       - main
-
-# - name: sonar pr decoration
-#   image: maven:3.8-openjdk-17
-#   depends_on:
-#   - sonar
-#   environment:
-#     SONAR_HOST:
-#       from_secret: sonar_host
-#     SONAR_TOKEN:
-#       from_secret: sonar_token
-#   commands:
-#   - echo this is where I run the pull request decoration
-#   when:
-#     event:
-#       include:
-#       - pull_request
-
----
-kind: pipeline
-type: kubernetes
-name: sonar housekeeping
-
-trigger:
-  event:
-  - cron
-  cron:
-    include:
-    - nightly
-
-steps:
-- name: SonarQube housekeeping
-  image: quay.io/ukhomeofficedigital/cicd-actions-sonarqube-housekeeping:v1
-  settings:
-    sonarqube_host: https://sonarqube.digital.homeoffice.gov.uk/
-    sonarqube_token:
-      from_secret: sonar_token
-    sonarqube_project_prefix: 'callisto-jparest'
-    jira_project_key: 'eahw'
 
 ---
 kind: pipeline

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <!-- Sonar Properties -->
         <sonar.language>java</sonar.language>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <branchName></branchName>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
When PR's are merged into main. Sonarcloud isn't picking this up as the time to scan the main branch. If we leave the 
-Dsonar.branch.name property blank this will put the scan results under the long lived master branch in sonarcloud.

By adding the branch name step we can extract the branch name only on PR's. Which will leave the -Dsonar.branch.name empty when merging onto main allowing a scan of the main branch instead of creating a short-lived branch called main. 