### PR TITLE
tech/stop-sonarcloud-changing-project-name: add -Dsonar.projectName

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,6 +45,7 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
+  - echo $BRANCHNAME
   - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$BRANCHNAME -Dsonar.projectName=callisto-jparest
   when:
     event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
     - test
   commands:
     - echo $DRONE_BRANCH
-    - mvn -DbranchName=$DRONE_BRANCH -Dmaven.main.skip -DskipTests
+    - mvn -DbranchName=$DRONE_BRANCH -Dmaven.main.skip -DskipTests package
   when:
     branch:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,6 +47,7 @@ steps:
   commands:
   - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.projectName=callisto-jparest
   when:
+    branch: main
     event:
       exclude:
       - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,12 +19,13 @@ steps:
   commands:
   - mvn clean install
 
-- name: branch name
+- name: branch_name
   image: maven:3.8-openjdk-17
   depends_on:
     - test
   commands:
-    - "branchName=$(echo $DRONE_BRANCH)"
+    - echo $DRONE_BRANCH
+    - mvn -DbranchName=$DRONE_BRANCH
   when:
     branch:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,6 +13,9 @@ trigger:
     - push
     - pull_request
 
+environment:
+  BRANCHNAME:
+
 steps:
 - name: test
   image: maven:3.8-openjdk-17
@@ -25,7 +28,8 @@ steps:
     - test
   commands:
     - echo $DRONE_BRANCH
-    - mvn -DbranchName=$DRONE_BRANCH -Dmaven.main.skip -DskipTests package
+    - export BRANCHNAME=test
+    - echo $BRANCHNAME
   when:
     branch:
       exclude:
@@ -41,7 +45,7 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=${branchName} -Dsonar.projectName=callisto-jparest
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$BRANCHNAME -Dsonar.projectName=callisto-jparest
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
     - test
   commands:
     - echo $DRONE_BRANCH
-    - mvn -DbranchName=$DRONE_BRANCH
+    - mvn -DbranchName=$DRONE_BRANCH -Dmaven.main.skip -DskipTests
   when:
     branch:
       exclude:
@@ -41,7 +41,7 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName} -Dsonar.projectName=callisto-jparest
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=${branchName} -Dsonar.projectName=callisto-jparest
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,7 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName}
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$${branchName} -Dsonar.projectName=callisto-jparest
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,7 @@ steps:
     - test
   commands:
     - echo $DRONE_BRANCH
-    - export BRANCHNAME=test
+    - export BRANCHNAME=$DRONE_BRANCH
     - echo $BRANCHNAME
   when:
     branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,29 +13,29 @@ trigger:
     - push
     - pull_request
 
-environment:
-  BRANCHNAME:
-
 steps:
 - name: test
   image: maven:3.8-openjdk-17
   commands:
   - mvn clean install
 
-- name: branch_name
+- name: sonar branch
   image: maven:3.8-openjdk-17
   depends_on:
     - test
+  environment:
+    SONAR_HOST:
+      from_secret: sonar_cloud_host
+    SONAR_TOKEN:
+      from_secret: sonar_cloud_token
   commands:
-    - echo $DRONE_BRANCH
-    - export BRANCHNAME=$DRONE_BRANCH
-    - echo $BRANCHNAME
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$DRONE_BRANCH -Dsonar.projectName=callisto-jparest
   when:
     branch:
       exclude:
         - main
 
-- name: sonar
+- name: sonar main
   image: maven:3.8-openjdk-17
   depends_on:
   - test
@@ -45,8 +45,7 @@ steps:
     SONAR_TOKEN:
       from_secret: sonar_cloud_token
   commands:
-  - echo $BRANCHNAME
-  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$BRANCHNAME -Dsonar.projectName=callisto-jparest
+  - mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.projectName=callisto-jparest
   when:
     event:
       exclude:

--- a/.drone.yml
+++ b/.drone.yml
@@ -19,7 +19,7 @@ steps:
   commands:
   - mvn clean install
 
-- name: sonar branch
+- name: sonar_branch
   image: maven:3.8-openjdk-17
   depends_on:
     - test
@@ -35,7 +35,7 @@ steps:
       exclude:
       - main
 
-- name: sonar main
+- name: sonar_main
   image: maven:3.8-openjdk-17
   depends_on:
     - test
@@ -54,7 +54,7 @@ steps:
 - name: publish
   image: maven:3.8-openjdk-17
   depends_on:
-    - sonar
+    - sonar_main
   environment:
     ARTIFACTORY_TOKEN:
         from_secret: artifactory_token
@@ -87,7 +87,7 @@ steps:
 - name: snapshot
   image: maven:3.8-openjdk-17
   depends_on:
-    - sonar
+    - sonar_branch
   environment:
     ARTIFACTORY_TOKEN:
       from_secret: artifactory_token

--- a/.drone.yml
+++ b/.drone.yml
@@ -38,7 +38,7 @@ steps:
 - name: sonar main
   image: maven:3.8-openjdk-17
   depends_on:
-  - test
+    - test
   environment:
     SONAR_HOST:
       from_secret: sonar_cloud_host
@@ -49,7 +49,7 @@ steps:
   when:
     event:
       exclude:
-      - pull_request
+        - pull_request
 
 - name: publish
   image: maven:3.8-openjdk-17

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
   when:
     branch:
       exclude:
-        - main
+      - main
 
 - name: sonar main
   image: maven:3.8-openjdk-17
@@ -49,7 +49,7 @@ steps:
   when:
     event:
       exclude:
-        - pull_request
+      - pull_request
 
 - name: publish
   image: maven:3.8-openjdk-17

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.0.4</version>
+		<version>0.0.5</version>
 	</parent>
 
 	<properties>

--- a/git_tag.sh
+++ b/git_tag.sh
@@ -1,11 +1,19 @@
 version=
+branchName=test
 
-mkdir /root/.ssh/ && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
-ssh-keyscan github.com >> /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
-printf  "Host github.com\n   Hostname github.com\n   IdentityFile /root/.ssh/id_rsa\n" > /root/.ssh/config
-chmod 0600 /root/.ssh/config
-git remote add tag-origin  git@github.com:UKHomeOffice/callisto-jparest.git
-git tag $version
-git push tag-origin $version
+if [ $1 = "tag" ]
+then
+  mkdir /root/.ssh/ && echo "$SSH_KEY" > /root/.ssh/id_rsa && chmod 0600 /root/.ssh/id_rsa
+  ssh-keyscan github.com >> /root/.ssh/known_hosts && chmod 600 /root/.ssh/known_hosts
+  printf  "Host github.com\n   Hostname github.com\n   IdentityFile /root/.ssh/id_rsa\n" > /root/.ssh/config
+  chmod 0600 /root/.ssh/config
+  git remote add tag-origin  git@github.com:UKHomeOffice/callisto-jparest.git
+  git tag $version
+  git push tag-origin $version
+
+elif [ $1 = "sonar" ]
+then
+      mvn sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-jparest -Dsonar.branch.name=$branchName -Dsonar.projectName=callisto-jparest
+fi
 
 

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.4</version>
+        <version>0.0.5</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <packaging>pom</packaging>
 
     <properties>
-        <project.version>0.0.4${snapshotSuffix}</project.version>
+        <project.version>0.0.5${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
         <!-- Sonar Properties -->
         <sonar.language>java</sonar.language>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-        <branchName></branchName>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
We noticed that the sonar cloud project for jparest had been renamed to parentpom.
by adding the -Dsonar.projectName variable to the maven command will force the project name to remain the same.