### PR TITLE
upgrade version to 0.0.7

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.0.6</version>
+		<version>0.0.7</version>
 	</parent>
 
 	<properties>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.6</version>
+        <version>0.0.7</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.0.6</version>
+    <version>0.0.7</version>
     <packaging>pom</packaging>
 
     <properties>
-        <project.version>0.0.6${snapshotSuffix}</project.version>
+        <project.version>0.0.7${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
upgrade version to 0.0.7 as 0.0.6 failed due to attempting to override non snap shot version