### PR TITLE
Eahw 2239/show clashing shifts in errors

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.0.9</version>
+		<version>0.0.10</version>
 	</parent>
 
 	<properties>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -92,6 +92,10 @@
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
 
     </dependencies>
 

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -87,6 +87,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.9</version>
+        <version>0.0.10</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -87,11 +87,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>com.googlecode.json-simple</groupId>
-            <artifactId>json-simple</artifactId>
-            <version>1.1.1</version>
-        </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
@@ -1,5 +1,7 @@
 package uk.gov.homeoffice.digital.sas.jparest.exceptions;
 
+import java.util.Arrays;
+
 public class ResourceConstraintViolationException extends RuntimeException {
 
   public ResourceConstraintViolationException() {
@@ -8,6 +10,11 @@ public class ResourceConstraintViolationException extends RuntimeException {
 
   public ResourceConstraintViolationException(String s) {
     super(s);
+  }
+
+  public ResourceConstraintViolationException(Object[] o) {
+    super(
+            Arrays.toString(o));
   }
 
 }

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
@@ -1,20 +1,18 @@
 package uk.gov.homeoffice.digital.sas.jparest.exceptions;
 
-import java.util.Arrays;
+import lombok.Getter;
 
 public class ResourceConstraintViolationException extends RuntimeException {
 
-  public ResourceConstraintViolationException() {
-    super();
-  }
+  @Getter
+  private Object[] errorResponse = {};
 
   public ResourceConstraintViolationException(String s) {
     super(s);
   }
 
   public ResourceConstraintViolationException(Object[] o) {
-    super(
-            Arrays.toString(o));
+    this.errorResponse = o;
   }
 
 }

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
@@ -5,11 +5,7 @@ import lombok.Getter;
 public class ResourceConstraintViolationException extends RuntimeException {
 
   @Getter
-  private Object[] errorResponse = {};
-
-  public ResourceConstraintViolationException(String s) {
-    super(s);
-  }
+  private final Object[] errorResponse;
 
   public ResourceConstraintViolationException(Object[] o) {
     this.errorResponse = o;

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ResourceConstraintViolationException.java
@@ -1,13 +1,14 @@
 package uk.gov.homeoffice.digital.sas.jparest.exceptions;
 
+import java.util.List;
 import lombok.Getter;
 
 public class ResourceConstraintViolationException extends RuntimeException {
 
   @Getter
-  private final Object[] errorResponse;
+  private final List<StructuredError> errorResponse;
 
-  public ResourceConstraintViolationException(Object[] o) {
+  public ResourceConstraintViolationException(List<StructuredError> o) {
     this.errorResponse = o;
   }
 

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/StructuredError.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/StructuredError.java
@@ -1,0 +1,17 @@
+package uk.gov.homeoffice.digital.sas.jparest.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public class StructuredError {
+
+  private final String field;
+  private final String message;
+  private final Object data;
+
+  public StructuredError(String field, String message, Object data) {
+    this.field = field;
+    this.message = message;
+    this.data = data;
+  }
+}

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/exceptionhandling/ApiResponseExceptionHandler.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/exceptionhandling/ApiResponseExceptionHandler.java
@@ -3,6 +3,7 @@ package uk.gov.homeoffice.digital.sas.jparest.exceptions.exceptionhandling;
 import static uk.gov.homeoffice.digital.sas.jparest.utils.ConstantHelper.SERVER_ERROR;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
 import java.util.logging.Logger;
 import javax.persistence.PersistenceException;
 import org.springframework.beans.TypeMismatchException;
@@ -14,6 +15,7 @@ import uk.gov.homeoffice.digital.sas.jparest.controller.ResourceApiController;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.InvalidFilterException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.ResourceConstraintViolationException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.ResourceNotFoundException;
+import uk.gov.homeoffice.digital.sas.jparest.exceptions.StructuredError;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.TenantIdMismatchException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.UnexpectedQueryResultException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.UnknownResourcePropertyException;
@@ -60,7 +62,7 @@ public class ApiResponseExceptionHandler {
   }
 
   @ExceptionHandler(ResourceConstraintViolationException.class)
-  public ResponseEntity<Object[]> handleResourceConstraintViolationException(
+  public ResponseEntity<List<StructuredError>> handleResourceConstraintViolationException(
           ResourceConstraintViolationException ex) {
 
     return new ResponseEntity<>(ex.getErrorResponse(), HttpStatus.BAD_REQUEST);

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/exceptionhandling/ApiResponseExceptionHandler.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/exceptionhandling/ApiResponseExceptionHandler.java
@@ -28,7 +28,6 @@ public class ApiResponseExceptionHandler {
     IllegalArgumentException.class,
     JsonProcessingException.class,
     InvalidFilterException.class,
-    ResourceConstraintViolationException.class,
     UnknownResourcePropertyException.class,
     TenantIdMismatchException.class
   })
@@ -58,6 +57,13 @@ public class ApiResponseExceptionHandler {
   public ResponseEntity<ApiErrorResponse> handleUnexpectedQueryResultException(
       UnexpectedQueryResultException ex) {
     return createResponseEntity(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(ResourceConstraintViolationException.class)
+  public ResponseEntity<Object[]> handleResourceConstraintViolationException(
+          ResourceConstraintViolationException ex) {
+
+    return new ResponseEntity<>(ex.getErrorResponse(), HttpStatus.BAD_REQUEST);
   }
 
   private static ResponseEntity<ApiErrorResponse> createResponseEntity(

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidator.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidator.java
@@ -2,6 +2,7 @@ package uk.gov.homeoffice.digital.sas.jparest.validation;
 
 import static java.util.stream.Collectors.groupingBy;
 
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -10,6 +11,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.NoProviderFoundException;
 import javax.validation.Validation;
 import javax.validation.Validator;
+import org.hibernate.validator.engine.HibernateConstraintViolation;
 import org.json.simple.JSONObject;
 import org.springframework.stereotype.Component;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.ResourceConstraintViolationException;
@@ -46,7 +48,11 @@ public class EntityValidator {
           Set<ConstraintViolation<Object>> constraintViolations) {
 
     var constraintViolation = constraintViolations.iterator().next();
-    var payload = constraintViolation.getConstraintDescriptor().getPayload();
+    @SuppressWarnings("unchecked")
+    var hibernateConstraintViolation = constraintViolation.unwrap(
+        HibernateConstraintViolation.class
+    );
+    var payload = hibernateConstraintViolation.getDynamicPayload(ArrayList.class);
 
     var result = constraintViolations.stream()
             .collect(groupingBy(ConstraintViolation::getPropertyPath))

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidator.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidator.java
@@ -52,7 +52,6 @@ public class EntityValidator {
     var hibernateConstraintViolation = constraintViolation.unwrap(
         HibernateConstraintViolation.class
     );
-    var payload = hibernateConstraintViolation.getDynamicPayload(ArrayList.class);
 
     return constraintViolations.stream()
             .collect(groupingBy(ConstraintViolation::getPropertyPath))
@@ -64,7 +63,7 @@ public class EntityValidator {
 
               return new StructuredError(entry.getKey().toString(),
                   propertyErrors,
-                  payload);
+                  hibernateConstraintViolation.getDynamicPayload(ArrayList.class));
             }).collect(Collectors.toList());
   }
 }

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.homeoffice.digital.sas.jparest.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -246,16 +247,26 @@ class ResourceApiControllerTest {
         Throwable thrown = catchThrowable(() -> controller.create(TENANT_ID, "{}"));
 
         assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
-        var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
+        var errorResponse = (((ResourceConstraintViolationException) thrown).getErrorResponse());
 
-        var firstError = (JSONObject) errorResponse[0];
-        assertThat(firstError.get("field")).isEqualTo("telephone");
-        assertThat(firstError.get("message")).isEqualTo("must not be empty");
+        JSONObject telephoneError = null;
+        JSONObject descriptionError = null;
+        for(var i = 0 ; i < errorResponse.length ; i++) {
+            var error = (JSONObject) errorResponse[i];
+            if (error.get("field").equals("telephone")) {
+                telephoneError = error;
+            } else {
+                descriptionError = error;
+            }
+        }
 
-        var secondError = (JSONObject) errorResponse[1];
-        assertThat(secondError.get("field")).isEqualTo("description");
-        assertThat(secondError.get("message")).isEqualTo("must not be empty");
+        assertThat(telephoneError.get("field")).isEqualTo("telephone");
+        assertThat(telephoneError.get("message")).isEqualTo("must not be empty");
+
+        assertThat(descriptionError.get("field")).isEqualTo("description");
+        assertThat(descriptionError.get("message")).isEqualTo("must not be empty");
     }
+
 
     @Test
     @Transactional
@@ -401,9 +412,19 @@ class ResourceApiControllerTest {
         assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
         var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
 
-        var firstError = (JSONObject) errorResponse[0];
-        assertThat(firstError.get("field")).isEqualTo("telephone");
-        assertThat(firstError.get("message")).isEqualTo("must not be empty");
+        JSONObject telephoneError = null;
+        JSONObject descriptionError = null;
+        for(var i = 0 ; i < errorResponse.length ; i++) {
+            var error = (JSONObject) errorResponse[i];
+            if (error.get("field").equals("telephone")) {
+                telephoneError = error;
+            } else {
+                descriptionError = error;
+            }
+        }
+
+        assertThat(telephoneError.get("field")).isEqualTo("telephone");
+        assertThat(telephoneError.get("message")).isEqualTo("must not be empty");
     }
 
     @Test

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
@@ -237,13 +237,13 @@ class ResourceApiControllerTest {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
                 controller.create(TENANT_ID, "{\"" + ID_FIELD_NAME + "\": \"" + DUMMY_A_ID_1 + "\"}"));
     }
-
-    @Test
-    void create_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
-        var controller = getResourceApiController(DummyEntityD.class);
-        assertThatExceptionOfType(ResourceConstraintViolationException.class).isThrownBy(() -> controller.create(TENANT_ID, "{}"))
-                .withMessageContainingAll("description", "telephone", "has the following error(s):");
-    }
+//
+//    @Test
+//    void create_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
+//        var controller = getResourceApiController(DummyEntityD.class);
+//        assertThatExceptionOfType(ResourceConstraintViolationException.class).isThrownBy(() -> controller.create(TENANT_ID, "{}"))
+//                .withMessageContainingAll("description", "telephone", "has the following error(s):");
+//    }
 
     @Test
     @Transactional
@@ -380,13 +380,13 @@ class ResourceApiControllerTest {
         var controller = getResourceApiController(DummyEntityA.class);
         assertThatNoException().isThrownBy(() -> controller.update(TENANT_ID, DUMMY_A_ID_1, "{}"));
     }
-
-    @Test
-    void update_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
-        var controller = getResourceApiController(DummyEntityD.class);
-        assertThatExceptionOfType(ResourceConstraintViolationException.class).isThrownBy(() -> controller.update(TENANT_ID, NON_EXISTENT_ID, "{}"))
-                .withMessageContainingAll("description", "telephone", "has the following error(s):");
-    }
+//
+//    @Test
+//    void update_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
+//        var controller = getResourceApiController(DummyEntityD.class);
+//        assertThatExceptionOfType(ResourceConstraintViolationException.class).isThrownBy(() -> controller.update(TENANT_ID, NON_EXISTENT_ID, "{}"))
+//                .withMessageContainingAll("description", "telephone", "has the following error(s):");
+//    }
 
     @Test
     @Transactional

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
@@ -267,7 +267,6 @@ class ResourceApiControllerTest {
         assertThat(descriptionError.get("message")).isEqualTo("must not be empty");
     }
 
-
     @Test
     @Transactional
     void create_requestTenantIdMatchesPayloadTenantId_resourceIsCreatedWithTenantId() throws JsonProcessingException {

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.homeoffice.digital.sas.jparest.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Named.named;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -237,13 +239,23 @@ class ResourceApiControllerTest {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
                 controller.create(TENANT_ID, "{\"" + ID_FIELD_NAME + "\": \"" + DUMMY_A_ID_1 + "\"}"));
     }
-//
-//    @Test
-//    void create_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
-//        var controller = getResourceApiController(DummyEntityD.class);
-//        assertThatExceptionOfType(ResourceConstraintViolationException.class).isThrownBy(() -> controller.create(TENANT_ID, "{}"))
-//                .withMessageContainingAll("description", "telephone", "has the following error(s):");
-//    }
+
+    @Test
+    void create_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
+        var controller = getResourceApiController(DummyEntityD.class);
+        Throwable thrown = catchThrowable(() -> controller.create(TENANT_ID, "{}"));
+
+        assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
+        var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
+
+        var firstError = (JSONObject) errorResponse[0];
+        assertThat(firstError.get("field")).isEqualTo("telephone");
+        assertThat(firstError.get("message")).isEqualTo("must not be empty");
+
+        var secondError = (JSONObject) errorResponse[1];
+        assertThat(secondError.get("field")).isEqualTo("description");
+        assertThat(secondError.get("message")).isEqualTo("must not be empty");
+    }
 
     @Test
     @Transactional
@@ -380,13 +392,19 @@ class ResourceApiControllerTest {
         var controller = getResourceApiController(DummyEntityA.class);
         assertThatNoException().isThrownBy(() -> controller.update(TENANT_ID, DUMMY_A_ID_1, "{}"));
     }
-//
-//    @Test
-//    void update_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
-//        var controller = getResourceApiController(DummyEntityD.class);
-//        assertThatExceptionOfType(ResourceConstraintViolationException.class).isThrownBy(() -> controller.update(TENANT_ID, NON_EXISTENT_ID, "{}"))
-//                .withMessageContainingAll("description", "telephone", "has the following error(s):");
-//    }
+
+    @Test
+    void update_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
+        var controller = getResourceApiController(DummyEntityD.class);
+        Throwable thrown = catchThrowable(() -> controller.create(TENANT_ID, "{}"));
+
+        assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
+        var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
+
+        var firstError = (JSONObject) errorResponse[0];
+        assertThat(firstError.get("field")).isEqualTo("telephone");
+        assertThat(firstError.get("message")).isEqualTo("must not be empty");
+    }
 
     @Test
     @Transactional

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiControllerTest.java
@@ -2,8 +2,6 @@ package uk.gov.homeoffice.digital.sas.jparest.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,6 +30,7 @@ import uk.gov.homeoffice.digital.sas.jparest.entityutils.testentities.DummyEntit
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.ResourceConstraintViolationException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.ResourceNotFoundException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.ResourceNotFoundExceptionMessageUtil;
+import uk.gov.homeoffice.digital.sas.jparest.exceptions.StructuredError;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.TenantIdMismatchException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.UnexpectedQueryResultException;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.UnknownResourcePropertyException;
@@ -247,24 +246,23 @@ class ResourceApiControllerTest {
         Throwable thrown = catchThrowable(() -> controller.create(TENANT_ID, "{}"));
 
         assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
-        var errorResponse = (((ResourceConstraintViolationException) thrown).getErrorResponse());
+        var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
 
-        JSONObject telephoneError = null;
-        JSONObject descriptionError = null;
-        for(var i = 0 ; i < errorResponse.length ; i++) {
-            var error = (JSONObject) errorResponse[i];
-            if (error.get("field").equals("telephone")) {
-                telephoneError = error;
+        StructuredError telephoneError = null;
+        StructuredError descriptionError = null;
+        for (StructuredError structuredError : errorResponse) {
+            if (structuredError.getField().equals("telephone")) {
+                telephoneError = structuredError;
             } else {
-                descriptionError = error;
+                descriptionError = structuredError;
             }
         }
 
-        assertThat(telephoneError.get("field")).isEqualTo("telephone");
-        assertThat(telephoneError.get("message")).isEqualTo("must not be empty");
+        assertThat(telephoneError.getField()).isEqualTo("telephone");
+        assertThat(telephoneError.getMessage()).isEqualTo("must not be empty");
 
-        assertThat(descriptionError.get("field")).isEqualTo("description");
-        assertThat(descriptionError.get("message")).isEqualTo("must not be empty");
+        assertThat(descriptionError.getField()).isEqualTo("description");
+        assertThat(descriptionError.getMessage()).isEqualTo("must not be empty");
     }
 
     @Test
@@ -406,24 +404,20 @@ class ResourceApiControllerTest {
     @Test
     void update_payloadViolatesEntityConstraints_resourceConstraintViolationExceptionThrown() {
         var controller = getResourceApiController(DummyEntityD.class);
-        Throwable thrown = catchThrowable(() -> controller.create(TENANT_ID, "{}"));
+        Throwable thrown = catchThrowable(() -> controller.update(TENANT_ID, NON_EXISTENT_ID, "{}"));
 
         assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
         var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
 
-        JSONObject telephoneError = null;
-        JSONObject descriptionError = null;
-        for(var i = 0 ; i < errorResponse.length ; i++) {
-            var error = (JSONObject) errorResponse[i];
-            if (error.get("field").equals("telephone")) {
-                telephoneError = error;
-            } else {
-                descriptionError = error;
+        StructuredError telephoneError = null;
+        for (StructuredError structuredError : errorResponse) {
+            if (structuredError.getField().equals("telephone")) {
+                telephoneError = structuredError;
             }
         }
 
-        assertThat(telephoneError.get("field")).isEqualTo("telephone");
-        assertThat(telephoneError.get("message")).isEqualTo("must not be empty");
+        assertThat(telephoneError.getField()).isEqualTo("telephone");
+        assertThat(telephoneError.getMessage()).isEqualTo("must not be empty");
     }
 
     @Test

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ApiResponseExceptionHandlerTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ApiResponseExceptionHandlerTest.java
@@ -1,8 +1,8 @@
 package uk.gov.homeoffice.digital.sas.jparest.exceptions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.json.JSONException;
-import org.json.JSONObject;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -71,20 +71,18 @@ class ApiResponseExceptionHandlerTest {
     }
 
     @Test
-    void handleResourceConstraintViolationException_badRequestWithErrorDataIsReturned() throws JSONException {
-        var error = new JSONObject();
-        error.put("field", "foo");
-        error.put("message", "bar");
-        error.put("data", null);
-        var errorResponse = new JSONObject[]{error};
+    void handleResourceConstraintViolationException_badRequestWithErrorDataIsReturned() {
+        var error = new StructuredError("foo", "bar", null);
+
+        List<StructuredError> errorResponse = new ArrayList<>();
+        errorResponse.add(error);
 
         var apiResponseExceptionHandler = new ApiResponseExceptionHandler();
         var exception = new ResourceConstraintViolationException(errorResponse);
         var response = apiResponseExceptionHandler.handleResourceConstraintViolationException(exception);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).isEqualTo(errorResponse);
+        assertThat(response.getBody()).isNotNull().isEqualTo(errorResponse);
     }
 
 

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ApiResponseExceptionHandlerTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/exceptions/ApiResponseExceptionHandlerTest.java
@@ -1,6 +1,8 @@
 package uk.gov.homeoffice.digital.sas.jparest.exceptions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -11,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.exceptionhandling.ApiErrorResponse;
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.exceptionhandling.ApiResponseExceptionHandler;
-import uk.gov.homeoffice.digital.sas.jparest.utils.ConstantHelper;
 
 import javax.persistence.PersistenceException;
 import java.util.UUID;
@@ -69,6 +70,23 @@ class ApiResponseExceptionHandlerTest {
         assertResponseData(response, exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    @Test
+    void handleResourceConstraintViolationException_badRequestWithErrorDataIsReturned() throws JSONException {
+        var error = new JSONObject();
+        error.put("field", "foo");
+        error.put("message", "bar");
+        error.put("data", null);
+        var errorResponse = new JSONObject[]{error};
+
+        var apiResponseExceptionHandler = new ApiResponseExceptionHandler();
+        var exception = new ResourceConstraintViolationException(errorResponse);
+        var response = apiResponseExceptionHandler.handleResourceConstraintViolationException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody()).isEqualTo(errorResponse);
+    }
+
 
     private void assertResponseData(ResponseEntity<ApiErrorResponse> response, String message, HttpStatus httpStatus) {
         assertThat(response.getStatusCode()).isEqualTo(httpStatus);
@@ -84,7 +102,6 @@ class ApiResponseExceptionHandlerTest {
                 Arguments.of(new IllegalArgumentException(ERROR_MESSAGE)),
                 Arguments.of(jsonProcessingException),
                 Arguments.of(new InvalidFilterException(ERROR_MESSAGE)),
-                Arguments.of(new ResourceConstraintViolationException(ERROR_MESSAGE)),
                 Arguments.of(new UnknownResourcePropertyException("unknownProperty", "resourceName")),
                 Arguments.of(new TenantIdMismatchException())
         );

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
@@ -66,7 +66,6 @@ class EntityValidatorTest {
             }
         }
 
-
         assertThat(telephoneError.get("field")).isEqualTo("telephone");
         assertThat(((String)telephoneError.get("message")).contains("numeric value out of bounds (<5 digits>.<0 digits> expected)")).isTrue();
         assertThat(((String)telephoneError.get("message")).contains("must be greater than 0")).isTrue();

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
@@ -38,20 +38,20 @@ class EntityValidatorTest {
             .isThrownBy(() -> entityValidator.validateAndThrowIfErrorsExist(entity));
     }
 
-    @Test
-    void validateAndThrowIfErrorsExist_constrainViolationsExist_validationErrorMessagesAreGroupedAndDisplayedForEachProperty() {
-
-        var entity = new DummyEntityD();
-        entity.setTelephone("-123456");
-
-        var entityValidator = new EntityValidator();
-
-        assertThatExceptionOfType(ResourceConstraintViolationException.class)
-            .isThrownBy(() -> entityValidator.validateAndThrowIfErrorsExist(entity))
-            .withMessageContainingAll(
-                "description has the following error(s): must not be empty",
-                "telephone has the following error(s): ",
-                "numeric value out of bounds (<5 digits>.<0 digits> expected)", "must be greater than 0");
-    }
+//    @Test
+//    void validateAndThrowIfErrorsExist_constrainViolationsExist_validationErrorMessagesAreGroupedAndDisplayedForEachProperty() {
+//
+//        var entity = new DummyEntityD();
+//        entity.setTelephone("-123456");
+//
+//        var entityValidator = new EntityValidator();
+//
+//        assertThatExceptionOfType(ResourceConstraintViolationException.class)
+//            .isThrownBy(() -> entityValidator.validateAndThrowIfErrorsExist(entity))
+//            .withMessageContainingAll(
+//                "description has the following error(s): must not be empty",
+//                "telephone has the following error(s): ",
+//                "numeric value out of bounds (<5 digits>.<0 digits> expected)", "must be greater than 0");
+//    }
 
 }

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.springframework.test.util.AssertionErrors.assertTrue;
 
 class EntityValidatorTest {
 
@@ -54,13 +55,24 @@ class EntityValidatorTest {
         assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
         var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
 
-        var firstError = (JSONObject) errorResponse[0];
-        assertThat(firstError.get("field")).isEqualTo("telephone");
-        assertThat(firstError.get("message")).isEqualTo("numeric value out of bounds (<5 digits>.<0 digits> expected), must be greater than 0");
+        JSONObject telephoneError = null;
+        JSONObject descriptionError = null;
+        for(var i = 0 ; i < errorResponse.length ; i++) {
+            var error = (JSONObject) errorResponse[i];
+            if (error.get("field").equals("telephone")) {
+                telephoneError = error;
+            } else {
+                descriptionError = error;
+            }
+        }
 
-        var secondError = (JSONObject) errorResponse[1];
-        assertThat(secondError.get("field")).isEqualTo("description");
-        assertThat(secondError.get("message")).isEqualTo("must not be empty");
+
+        assertThat(telephoneError.get("field")).isEqualTo("telephone");
+        assertThat(((String)telephoneError.get("message")).contains("numeric value out of bounds (<5 digits>.<0 digits> expected)")).isTrue();
+        assertThat(((String)telephoneError.get("message")).contains("must be greater than 0")).isTrue();
+
+        assertThat(descriptionError.get("field")).isEqualTo("description");
+        assertThat(descriptionError.get("message")).isEqualTo("must not be empty");
     }
 
 }

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.homeoffice.digital.sas.jparest.validation;
 
-import org.json.simple.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -8,12 +7,12 @@ import uk.gov.homeoffice.digital.sas.jparest.entityutils.testentities.DummyEntit
 import uk.gov.homeoffice.digital.sas.jparest.exceptions.ResourceConstraintViolationException;
 
 import javax.validation.Validation;
+import uk.gov.homeoffice.digital.sas.jparest.exceptions.StructuredError;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
-import static org.springframework.test.util.AssertionErrors.assertTrue;
 
 class EntityValidatorTest {
 
@@ -55,23 +54,22 @@ class EntityValidatorTest {
         assertThat(thrown).isInstanceOf(ResourceConstraintViolationException.class);
         var errorResponse = ((ResourceConstraintViolationException) thrown).getErrorResponse();
 
-        JSONObject telephoneError = null;
-        JSONObject descriptionError = null;
-        for(var i = 0 ; i < errorResponse.length ; i++) {
-            var error = (JSONObject) errorResponse[i];
-            if (error.get("field").equals("telephone")) {
-                telephoneError = error;
+        StructuredError telephoneError = null;
+        StructuredError descriptionError = null;
+        for (StructuredError structuredError : errorResponse) {
+            if (structuredError.getField().equals("telephone")) {
+                telephoneError = structuredError;
             } else {
-                descriptionError = error;
+                descriptionError = structuredError;
             }
         }
 
-        assertThat(telephoneError.get("field")).isEqualTo("telephone");
-        assertThat(((String)telephoneError.get("message")).contains("numeric value out of bounds (<5 digits>.<0 digits> expected)")).isTrue();
-        assertThat(((String)telephoneError.get("message")).contains("must be greater than 0")).isTrue();
+        assertThat(telephoneError.getField()).isEqualTo("telephone");
+        assertThat((telephoneError.getMessage()).contains("numeric value out of bounds (<5 digits>.<0 digits> expected)")).isTrue();
+        assertThat((telephoneError.getMessage()).contains("must be greater than 0")).isTrue();
 
-        assertThat(descriptionError.get("field")).isEqualTo("description");
-        assertThat(descriptionError.get("message")).isEqualTo("must not be empty");
+        assertThat(descriptionError.getField()).isEqualTo("description");
+        assertThat(descriptionError.getMessage()).isEqualTo("must not be empty");
     }
 
 }

--- a/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
+++ b/jparest/src/test/java/uk/gov/homeoffice/digital/sas/jparest/validation/EntityValidatorTest.java
@@ -38,20 +38,20 @@ class EntityValidatorTest {
             .isThrownBy(() -> entityValidator.validateAndThrowIfErrorsExist(entity));
     }
 
-//    @Test
-//    void validateAndThrowIfErrorsExist_constrainViolationsExist_validationErrorMessagesAreGroupedAndDisplayedForEachProperty() {
-//
-//        var entity = new DummyEntityD();
-//        entity.setTelephone("-123456");
-//
-//        var entityValidator = new EntityValidator();
-//
-//        assertThatExceptionOfType(ResourceConstraintViolationException.class)
-//            .isThrownBy(() -> entityValidator.validateAndThrowIfErrorsExist(entity))
-//            .withMessageContainingAll(
-//                "description has the following error(s): must not be empty",
-//                "telephone has the following error(s): ",
-//                "numeric value out of bounds (<5 digits>.<0 digits> expected)", "must be greater than 0");
-//    }
+    @Test
+    void validateAndThrowIfErrorsExist_constrainViolationsExist_validationErrorMessagesAreGroupedAndDisplayedForEachProperty() {
+
+        var entity = new DummyEntityD();
+        entity.setTelephone("-123456");
+
+        var entityValidator = new EntityValidator();
+
+        assertThatExceptionOfType(ResourceConstraintViolationException.class)
+            .isThrownBy(() -> entityValidator.validateAndThrowIfErrorsExist(entity))
+            .withMessageContainingAll(
+                "description has the following error(s): must not be empty",
+                "telephone has the following error(s): ",
+                "numeric value out of bounds (<5 digits>.<0 digits> expected)", "must be greater than 0");
+    }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.0.9</version>
+    <version>0.0.10</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <project.version>0.0.9${snapshotSuffix}</project.version>
+        <project.version>0.0.10${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Reformat constraint violation responses to have a structured format, returning an array of errors containing field, message and data.

e.g.:
```
[
  {
    "field": "startTime",
    "data": [
      {
        "timePeriodTypeId": "00000000-0000-0000-0000-000000000001",
        "startTime": "2022-11-09T15:08:47.378+00:00",
        "endTime": "2022-11-09T15:08:47.378+00:00"
      }
    ],
    "message": "Time periods must not overlap with another time period"
  }
]
```