### PR TITLE
Allow kebab case resource type

### DIFF
--- a/cucumber-jparest/README.md
+++ b/cucumber-jparest/README.md
@@ -13,9 +13,13 @@ JpaRest library.
 The tests for this library are themselves written in gherkin and
 executed by cucumber.
 
-Therefore the living documentation of what features the cucumber-jparest
-supports are the [feature files](src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/)
+Therefore, the living documentation of what features the cucumber-jparest
+supports are the [feature files](src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest)
 themselves.
+
+Note that the features under [test folder](src/test/resources/test) are used as internal tests 
+for cucumber-jparest itself and should not be regarded as an example of how cucumber-jparest is 
+supposed to be used by third party projects
 
 ## Getting Started
 

--- a/cucumber-jparest/pom.xml
+++ b/cucumber-jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/cucumber-jparest/pom.xml
+++ b/cucumber-jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.12</version>
+        <version>0.0.13</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/JpaRestApiClient.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/JpaRestApiClient.java
@@ -30,7 +30,7 @@ public class JpaRestApiClient {
   @SuppressWarnings("squid:S1075") // URIs should not be hardcoded
   public static final String API_ROOT_PATH = "/resources/";
   public static final String TENANT_ID_PARAM_NAME = "tenantId";
-  public static final String TENANT_ID_SYSTEM_PROPERTY_NAME = "cucumber.jparest.tenantId";
+
   @Getter
   private final ServiceRegistry serviceRegistry;
 
@@ -79,21 +79,19 @@ public class JpaRestApiClient {
    * Creates resources in the specified service using the provided payload.
    *
    * @param persona  The persona making the request.
-   * @param tenantId The tenant ID; if not supplied fallback on system property
    * @param service  The name of the service where the resources will be created. The service name
    *                 must exist in the {@link ServiceRegistry}
    * @param resource The name of the type of resource to create
    * @param payload  The resource to create
    * @return JpaRestApiResourceResponse
    */
-  public JpaRestApiResourceResponse create(Persona persona, String tenantId, String service,
+  public JpaRestApiResourceResponse create(Persona persona, String service,
       String resource, String payload) {
     URI uri = getResourceUri(service, resource);
     RequestSpecification spec = given()
         .baseUri(uri.toString())
         .body(payload)
-        .queryParam(TENANT_ID_PARAM_NAME,
-            tenantId == null ? System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME) : tenantId);
+        .queryParam(TENANT_ID_PARAM_NAME, persona.getTenantId().toString());
 
     addPersonaAuthToRequestSpecification(spec, persona);
 
@@ -107,21 +105,19 @@ public class JpaRestApiClient {
    * Retrieves resources in the specified service using the provided filter.
    *
    * @param persona    The persona making the request.
-   * @param tenantId   The tenant ID; if not supplied fallback on system property
    * @param service    The name of the service where the resources will be retrieved from. The
    *                   service name must exist in the {@link ServiceRegistry}
    * @param resource   The name of the type of resource to be retrieved
    * @param parameters The query string parameters to add to the requested url
    * @return JpaRestApiResourceResponse
    */
-  public JpaRestApiResourceResponse retrieve(Persona persona, String tenantId, String service,
+  public JpaRestApiResourceResponse retrieve(Persona persona, String service,
       String resource, Map<String, String> parameters) {
     URI uri = getResourceUri(service, resource);
 
     RequestSpecification spec = given()
         .baseUri(uri.toString())
-        .queryParam(TENANT_ID_PARAM_NAME,
-            tenantId == null ? System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME) : tenantId);
+        .queryParam(TENANT_ID_PARAM_NAME, persona.getTenantId().toString());
 
     if (parameters != null) {
       spec = spec.queryParams(parameters);
@@ -140,21 +136,19 @@ public class JpaRestApiClient {
    * Retrieves resources in the specified service using the specified reference.
    *
    * @param persona   The persona making the request.
-   * @param tenantId  The tenant ID; if not supplied fallback on system property
    * @param service   The name of the service where the resource will be retrieved from. The service
    *                  name must exist in the {@link ServiceRegistry}
    * @param resource  The name of the type of resource to be retrieved
    * @param reference The identifier of the resource to be retrieved
    * @return JpaRestApiResourceResponse
    */
-  public JpaRestApiResourceResponse retrieveById(Persona persona, String tenantId, String service,
+  public JpaRestApiResourceResponse retrieveById(Persona persona, String service,
       String resource, String reference) {
     URI uri = getResourceUri(service, resource);
 
     RequestSpecification spec = given()
         .baseUri(uri.toString())
-        .queryParam(TENANT_ID_PARAM_NAME,
-            tenantId == null ? System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME) : tenantId);
+        .queryParam(TENANT_ID_PARAM_NAME, persona.getTenantId().toString());
 
     addPersonaAuthToRequestSpecification(spec, persona);
 
@@ -170,7 +164,6 @@ public class JpaRestApiClient {
    * Updates resources in the specified service using the provided payload.
    *
    * @param persona   The persona making the request.
-   * @param tenantId  The tenant ID; if not supplied fallback on system property
    * @param service   The name of the service where the resources will be updated. The service name
    *                  must exist in the {@link ServiceRegistry}
    * @param resource  The name of the type of resource to update
@@ -178,15 +171,14 @@ public class JpaRestApiClient {
    * @param payload   The updated resource
    * @return JpaRestApiResourceResponse
    */
-  public JpaRestApiResourceResponse update(Persona persona, String tenantId, String service,
+  public JpaRestApiResourceResponse update(Persona persona, String service,
       String resource, String reference, String payload) {
 
     URI uri = getResourceUri(service, resource);
     RequestSpecification spec = given()
         .baseUri(uri.toString())
         .body(payload)
-        .queryParam(TENANT_ID_PARAM_NAME,
-            tenantId == null ? System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME) : tenantId);
+        .queryParam(TENANT_ID_PARAM_NAME, persona.getTenantId().toString());
 
     addPersonaAuthToRequestSpecification(spec, persona);
 
@@ -201,21 +193,19 @@ public class JpaRestApiClient {
    * Deletes resources in the specified service with the specified reference.
    *
    * @param persona   The persona making the request.
-   * @param tenantId  The tenant ID; if not supplied fallback on system property
    * @param service   The name of the service where the resources will be deleted. The service name
    *                  must exist in the {@link ServiceRegistry}
    * @param resource  The name of the type of resource to deleted
    * @param reference The identifier of the resource to be deleted
    * @return JpaRestApiResourceResponse
    */
-  public JpaRestApiResourceResponse delete(Persona persona, String tenantId, String service,
+  public JpaRestApiResourceResponse delete(Persona persona, String service,
       String resource, String reference) {
     URI uri = getResourceUri(service, resource);
 
     RequestSpecification spec = given()
         .baseUri(uri.toString())
-        .queryParam(TENANT_ID_PARAM_NAME,
-            tenantId == null ? System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME) : tenantId);
+        .queryParam(TENANT_ID_PARAM_NAME, persona.getTenantId().toString());
 
     addPersonaAuthToRequestSpecification(spec, persona);
 
@@ -231,19 +221,17 @@ public class JpaRestApiClient {
    * resource path or any other endpoint (e.g. openAPI)
    *
    * @param persona  The persona making the request.
-   * @param tenantId The tenant ID; if not supplied fallback on system property
    * @param service  The name of the service where the resources will be retrieved from. The service
    *                 name must exist in the {@link ServiceRegistry}
    * @param path     The relative path to make the GET request to
    * @return JpaRestApiResponse
    */
-  public JpaRestApiResponse get(Persona persona, String tenantId, String service, String path) {
+  public JpaRestApiResponse get(Persona persona, String service, String path) {
     URI url = getServiceUrl(service, path);
 
     RequestSpecification spec = given()
         .baseUri(url.toString())
-        .queryParam(TENANT_ID_PARAM_NAME,
-            tenantId == null ? System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME) : tenantId);
+        .queryParam(TENANT_ID_PARAM_NAME, persona.getTenantId().toString());
 
     addPersonaAuthToRequestSpecification(spec, persona);
 

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ResourceHelper.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ResourceHelper.java
@@ -1,5 +1,8 @@
 package uk.gov.homeoffice.digital.sas.cucumberjparest.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.response.ResponseBody;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +11,7 @@ import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.Persona;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.PersonaManager;
 
 @Component
+@SuppressWarnings("squid:S5960")
 public class ResourceHelper {
 
   private final JpaRestApiClient jpaRestApiClient;
@@ -20,13 +24,32 @@ public class ResourceHelper {
     this.personaManager = personaManager;
   }
 
+  /**
+   * Returns unique and non-empty resource ID for the specified arguments.
+   *
+   * @param personaName  Person name, e.g. Trevor
+   * @param service      Service name, e.g. timecard
+   * @param resourceType Resource type, e.g. time-period-types
+   * @param filter       filter to be applied, e.g. name="Shift"
+   * @return Unique and non-empty resource ID
+   */
   public String getResourceId(String personaName, String service, String resourceType,
       String filter) {
     Persona persona = personaManager.getPersona(personaName);
     Map<String, String> params = new HashMap<>();
     params.put("filter", filter);
-    // TODO assert getBody().items.size()==1
-    return jpaRestApiClient.retrieve(persona, service, resourceType, params)
-            .getResponse().getBody().jsonPath().get("items[0].id");
+
+    ResponseBody responseBody = jpaRestApiClient.retrieve(persona, service, resourceType, params)
+        .getResponse().getBody();
+
+    Integer numberOfItems = responseBody.jsonPath().get("items.size()");
+    // Response must have one and only one item
+    assertThat(numberOfItems).isEqualTo(1);
+
+    String resourceId = responseBody.jsonPath().get("items[0].id");
+    // Item must have a non-empty id
+    assertThat(resourceId).isNotBlank();
+
+    return resourceId;
   }
 }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ResourceHelper.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ResourceHelper.java
@@ -1,0 +1,32 @@
+package uk.gov.homeoffice.digital.sas.cucumberjparest.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.Persona;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.PersonaManager;
+
+@Component
+public class ResourceHelper {
+
+  private final JpaRestApiClient jpaRestApiClient;
+
+  private final PersonaManager personaManager;
+
+  @Autowired
+  public ResourceHelper(JpaRestApiClient jpaRestApiClient, PersonaManager personaManager) {
+    this.jpaRestApiClient = jpaRestApiClient;
+    this.personaManager = personaManager;
+  }
+
+  public String getResourceId(String personaName, String service, String resourceType,
+      String filter) {
+    Persona persona = personaManager.getPersona(personaName);
+    Map<String, String> params = new HashMap<>();
+    params.put("filter", filter);
+    // TODO assert getBody().items.size()==1
+    return jpaRestApiClient.retrieve(persona, service, resourceType, params)
+            .getResponse().getBody().jsonPath().get("items[0].id");
+  }
+}

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ServiceRegistry.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ServiceRegistry.java
@@ -1,10 +1,10 @@
 package uk.gov.homeoffice.digital.sas.cucumberjparest.api;
 
 import java.util.Map;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.stereotype.Component;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.utils.SerialisationUtil;
 
 /**
 * Registry for services and their location.
@@ -12,11 +12,16 @@ import org.springframework.stereotype.Component;
 @Getter
 @Setter
 @Component
-@AllArgsConstructor
 public class ServiceRegistry {
 
   public static final String SERVICE_REGISTRY_SYSTEM_PROPERTY_NAME
       = "cucumber.jparest.serviceRegistry";
+
+  public ServiceRegistry() {
+    String serviceRegistryString = System.getProperty(SERVICE_REGISTRY_SYSTEM_PROPERTY_NAME);
+    this.services = SerialisationUtil.stringToMap(serviceRegistryString);
+  }
+
   private Map<String, String> services;
 
   /**

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
@@ -93,7 +93,6 @@ public class JpaTestContext {
    *
    * @return JpaRestApiClient
    */
-  // @ScenarioScope
   @Bean
   public JpaRestApiClient jpaRestApiClient() {
     return new JpaRestApiClient(serviceRegistry());

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
@@ -5,6 +5,7 @@ import static uk.gov.homeoffice.digital.sas.cucumberjparest.api.ServiceRegistry.
 import io.cucumber.spring.ScenarioScope;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
@@ -117,4 +118,8 @@ public class JpaTestContext {
     return new Interpolation(beanFactory);
   }
 
+  @Bean
+  public Map<String, String> sharedVariables() {
+    return new HashMap<>();
+  }
 }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
@@ -5,7 +5,6 @@ import static uk.gov.homeoffice.digital.sas.cucumberjparest.api.ServiceRegistry.
 import io.cucumber.spring.ScenarioScope;
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.api.HttpResponseManager;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.api.JpaRestApiClient;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.api.PayloadManager;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.api.ResourceHelper;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.api.ServiceRegistry;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.PersonaManager;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.scenarios.ScenarioState;
@@ -103,6 +103,7 @@ public class JpaTestContext {
    *
    * @return JpaRestApiClient
    */
+  // @ScenarioScope
   @Bean
   public JpaRestApiClient jpaRestApiClient() {
     return new JpaRestApiClient(serviceRegistry());
@@ -119,7 +120,7 @@ public class JpaTestContext {
   }
 
   @Bean
-  public Map<String, String> sharedVariables() {
-    return new HashMap<>();
+  public ResourceHelper resourceHelper() {
+    return new ResourceHelper(jpaRestApiClient(), personaManager());
   }
 }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/config/JpaTestContext.java
@@ -1,13 +1,10 @@
 package uk.gov.homeoffice.digital.sas.cucumberjparest.config;
 
-import static uk.gov.homeoffice.digital.sas.cucumberjparest.api.ServiceRegistry.SERVICE_REGISTRY_SYSTEM_PROPERTY_NAME;
-
 import io.cucumber.spring.ScenarioScope;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +16,6 @@ import uk.gov.homeoffice.digital.sas.cucumberjparest.api.ServiceRegistry;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.PersonaManager;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.scenarios.ScenarioState;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.scenarios.interpolation.Interpolation;
-import uk.gov.homeoffice.digital.sas.cucumberjparest.utils.SerialisationUtil;
 
 /**
  * Class used by the {Link ContextConfiguration} annotation to configure an
@@ -38,11 +34,6 @@ public class JpaTestContext {
       Map.class.getSimpleName(), Map.class,
       List.class.getSimpleName(), List.class,
       Instant.class.getSimpleName(), Instant.class);
-  private static final String SERVICE_REGISTRY_SYSTEM_PROPERTY_EL
-      = "#{systemProperties['" + SERVICE_REGISTRY_SYSTEM_PROPERTY_NAME + "']}";
-
-  @Value(SERVICE_REGISTRY_SYSTEM_PROPERTY_EL)
-  private String serviceRegistryString;
 
   /**
    * The service registry needs to be accessed to by the Cucumber context and the test runner so
@@ -50,8 +41,7 @@ public class JpaTestContext {
    */
   @Bean
   public ServiceRegistry serviceRegistry() {
-    Map<String, String> servicesMap = SerialisationUtil.stringToMap(serviceRegistryString);
-    return new ServiceRegistry(servicesMap);
+    return new ServiceRegistry();
   }
 
   /**

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/Persona.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/Persona.java
@@ -2,6 +2,7 @@ package uk.gov.homeoffice.digital.sas.cucumberjparest.persona;
 
 import static uk.gov.homeoffice.digital.sas.cucumberjparest.utils.SecureRandomStringGenerator.randomAlphabetic;
 
+import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,4 +20,7 @@ public class Persona {
   @Setter
   private String id = randomAlphabetic(10);
 
+  @Getter
+  @Setter
+  private UUID tenantId;
 }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/PersonaManager.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/PersonaManager.java
@@ -17,7 +17,7 @@ public class PersonaManager {
 
   public static final String TENANT_ID_SYSTEM_PROPERTY_NAME = "cucumber.jparest.tenantId";
 
-  private final String tenantId;
+  private final UUID tenantId;
 
   // Holds that state for Personas against the provide persona name
   private final Map<String, Persona> personas = new HashMap<>();
@@ -28,7 +28,7 @@ public class PersonaManager {
    * requests.
    */
   public PersonaManager() {
-    this.tenantId = System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME);
+    this.tenantId = UUID.fromString(System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME));
     this.createPersona("someone");
   }
 
@@ -43,7 +43,7 @@ public class PersonaManager {
       throw new IllegalArgumentException(name + " already exists");
     }
     Persona persona = new Persona();
-    persona.setTenantId(UUID.fromString(tenantId));
+    persona.setTenantId(tenantId);
     personas.put(name, persona);
     return persona;
   }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/PersonaManager.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/PersonaManager.java
@@ -10,10 +10,14 @@ import org.springframework.stereotype.Component;
  * When new personas are created they can be given any
  * name. This name is used as a variable to reference
  * the persona instance in later steps within a scenario.
- * 
+ *
  */
 @Component
 public class PersonaManager {
+
+  public static final String TENANT_ID_SYSTEM_PROPERTY_NAME = "cucumber.jparest.tenantId";
+
+  private final String tenantId;
 
   // Holds that state for Personas against the provide persona name
   private final Map<String, Persona> personas = new HashMap<>();
@@ -27,10 +31,6 @@ public class PersonaManager {
     this.tenantId = System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME);
     this.createPersona("someone");
   }
-
-  public static final String TENANT_ID_SYSTEM_PROPERTY_NAME = "cucumber.jparest.tenantId";
-
-  private final String tenantId;
 
   /**
    * Creates a new persona with the given name.

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/PersonaManager.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/persona/PersonaManager.java
@@ -2,6 +2,7 @@ package uk.gov.homeoffice.digital.sas.cucumberjparest.persona;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import org.springframework.stereotype.Component;
 
 /**
@@ -23,8 +24,13 @@ public class PersonaManager {
    * requests.
    */
   public PersonaManager() {
+    this.tenantId = System.getProperty(TENANT_ID_SYSTEM_PROPERTY_NAME);
     this.createPersona("someone");
   }
+
+  public static final String TENANT_ID_SYSTEM_PROPERTY_NAME = "cucumber.jparest.tenantId";
+
+  private final String tenantId;
 
   /**
    * Creates a new persona with the given name.
@@ -37,6 +43,7 @@ public class PersonaManager {
       throw new IllegalArgumentException(name + " already exists");
     }
     Persona persona = new Persona();
+    persona.setTenantId(UUID.fromString(tenantId));
     personas.put(name, persona);
     return persona;
   }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/parametertypes/ParameterTypes.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/parametertypes/ParameterTypes.java
@@ -65,7 +65,7 @@ public class ParameterTypes {
    * @param resourceType The type of resource represented
    * @return PayloadKey
    */
-  @ParameterType("(?:the )?(\\w+) ([\\w-]*)")
+  @ParameterType("(?:the )?(\\w+) ([\\w-]+)")
   public PayloadKey payload(String payloadName, String resourceType) {
     return new PayloadKey(resourceType, payloadName);
   }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/parametertypes/ParameterTypes.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/parametertypes/ParameterTypes.java
@@ -65,7 +65,7 @@ public class ParameterTypes {
    * @param resourceType The type of resource represented
    * @return PayloadKey
    */
-  @ParameterType("(?:the )?(\\w+) (\\w+)")
+  @ParameterType("(?:the )?(\\w+) ([\\w-]*)")
   public PayloadKey payload(String payloadName, String resourceType) {
     return new PayloadKey(resourceType, payloadName);
   }

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/stepdefinitions/ApiSteps.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/stepdefinitions/ApiSteps.java
@@ -43,7 +43,7 @@ public class ApiSteps {
       String service) {
 
     String payload = this.payloadManager.getPayload(payloadKey);
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.create(persona, null,
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.create(persona,
         service, payloadKey.getResourceType(), payload);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
@@ -60,7 +60,7 @@ public class ApiSteps {
   @When("{persona} retrieves {word}{service}")
   public void personaRetrievesResourcesFromTheService(Persona persona, String resource,
       String service) {
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, null, service,
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, service,
         resource, null);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
@@ -79,7 +79,7 @@ public class ApiSteps {
   public void personaRetrievesResourcesFromTheService(Persona persona, String resource,
       String service,
       Map<String, String> parameters) {
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, null, service,
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, service,
         resource, parameters);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
@@ -95,7 +95,7 @@ public class ApiSteps {
    */
   @When("{persona} GETs {string}{service}")
   public void personaGetsUrlFromService(Persona persona, String path, String service) {
-    JpaRestApiResponse apiResponse = this.jpaRestApiClient.get(persona, null, service, path);
+    JpaRestApiResponse apiResponse = this.jpaRestApiClient.get(persona, service, path);
 
     this.httpResponseManager.addResponse(apiResponse.getUri(), apiResponse.getResponse());
   }
@@ -113,7 +113,7 @@ public class ApiSteps {
       String resource,
       String identifier, String service) {
     JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieveById(persona,
-        null, service, resource, identifier);
+        service, resource, identifier);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
         apiResponse.getResponse());
@@ -129,7 +129,7 @@ public class ApiSteps {
   @When("{persona} deletes the {resource}{service}")
   public void personaDeletesTheResource(Persona persona, Resource resource, String service) {
     String reference = resource.getJsonPath().getString("id");
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.delete(persona, null,
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.delete(persona,
         service, resource.getResourceType(), reference);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
@@ -150,7 +150,7 @@ public class ApiSteps {
 
     String reference = resource.getJsonPath().getString("id");
     String payload = this.payloadManager.getPayload(payloadKey);
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.update(persona, null, service,
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.update(persona, service,
         payloadKey.getResourceType(), reference, payload);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/stepdefinitions/ApiSteps.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/stepdefinitions/ApiSteps.java
@@ -43,9 +43,8 @@ public class ApiSteps {
       String service) {
 
     String payload = this.payloadManager.getPayload(payloadKey);
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.create(persona, service,
-        payloadKey.getResourceType(),
-        payload);
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.create(persona, null,
+        service, payloadKey.getResourceType(), payload);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
         apiResponse.getResponse());
@@ -61,7 +60,7 @@ public class ApiSteps {
   @When("{persona} retrieves {word}{service}")
   public void personaRetrievesResourcesFromTheService(Persona persona, String resource,
       String service) {
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, service,
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, null, service,
         resource, null);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
@@ -80,7 +79,7 @@ public class ApiSteps {
   public void personaRetrievesResourcesFromTheService(Persona persona, String resource,
       String service,
       Map<String, String> parameters) {
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, service,
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieve(persona, null, service,
         resource, parameters);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
@@ -96,7 +95,7 @@ public class ApiSteps {
    */
   @When("{persona} GETs {string}{service}")
   public void personaGetsUrlFromService(Persona persona, String path, String service) {
-    JpaRestApiResponse apiResponse = this.jpaRestApiClient.get(persona, service, path);
+    JpaRestApiResponse apiResponse = this.jpaRestApiClient.get(persona, null, service, path);
 
     this.httpResponseManager.addResponse(apiResponse.getUri(), apiResponse.getResponse());
   }
@@ -113,9 +112,8 @@ public class ApiSteps {
   public void personaRetrieveSpecificResourcesFromTheService(Persona persona,
       String resource,
       String identifier, String service) {
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieveById(persona, service,
-        resource,
-        identifier);
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.retrieveById(persona,
+        null, service, resource, identifier);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
         apiResponse.getResponse());
@@ -131,8 +129,8 @@ public class ApiSteps {
   @When("{persona} deletes the {resource}{service}")
   public void personaDeletesTheResource(Persona persona, Resource resource, String service) {
     String reference = resource.getJsonPath().getString("id");
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.delete(persona, service,
-        resource.getResourceType(), reference);
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.delete(persona, null,
+        service, resource.getResourceType(), reference);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
         apiResponse.getResponse());
@@ -152,9 +150,8 @@ public class ApiSteps {
 
     String reference = resource.getJsonPath().getString("id");
     String payload = this.payloadManager.getPayload(payloadKey);
-    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.update(persona, service,
-        payloadKey.getResourceType(), reference,
-        payload);
+    JpaRestApiResourceResponse apiResponse = this.jpaRestApiClient.update(persona, null, service,
+        payloadKey.getResourceType(), reference, payload);
 
     this.httpResponseManager.addResponse(apiResponse.getBaseResourceUri(),
         apiResponse.getResponse());

--- a/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/utils/ExpectationUtils.java
+++ b/cucumber-jparest/src/main/java/uk/gov/homeoffice/digital/sas/cucumberjparest/utils/ExpectationUtils.java
@@ -207,7 +207,7 @@ public class ExpectationUtils {
     } catch (SpelParseException ex) {
       softly.fail("Invalid expectation: " + expectation);
     } catch (EvaluationException ex) {
-      // If an expectation exectued correctly but failed retrieve the underlying cause
+      // If an expectation executed correctly but failed retrieve the underlying cause
       // to expose the failed expectation
       var cause = ex.getCause();
       if (cause != null) {

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/RunCucumberIntegrationTest.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/RunCucumberIntegrationTest.java
@@ -12,7 +12,8 @@ import org.junit.platform.suite.api.Suite;
 @Suite
 @IncludeEngines("cucumber")
 @SelectClasspathResource("uk/gov/homeoffice/digital/sas/cucumberjparest")
-@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "uk.gov.homeoffice.digital.sas.cucumberjparest")
+@SelectClasspathResource("test")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "uk.gov.homeoffice.digital.sas.cucumberjparest,uk.gov.homeoffice.digital.sas.cucumberjparesttestapi")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty,html:target/cucumber-report.html")
 @ConfigurationParameter(key = OBJECT_FACTORY_PROPERTY_NAME, value = "io.cucumber.spring.SpringFactory")
 @SuppressWarnings("squid:S2187")//Actual tests are BDD features under resources folder

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/RunCucumberIntegrationTest.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/RunCucumberIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.platform.suite.api.Suite;
 @IncludeEngines("cucumber")
 @SelectClasspathResource("uk/gov/homeoffice/digital/sas/cucumberjparest")
 @SelectClasspathResource("test")
-@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "uk.gov.homeoffice.digital.sas.cucumberjparest,uk.gov.homeoffice.digital.sas.cucumberjparesttestapi")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "uk.gov.homeoffice.digital.sas.cucumberjparest,uk.gov.homeoffice.digital.sas.cucumberjparest.testapi")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty,html:target/cucumber-report.html")
 @ConfigurationParameter(key = OBJECT_FACTORY_PROPERTY_NAME, value = "io.cucumber.spring.SpringFactory")
 @SuppressWarnings("squid:S2187")//Actual tests are BDD features under resources folder

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/StepDefinitionsTest.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/StepDefinitionsTest.java
@@ -15,7 +15,7 @@ import io.cucumber.java.en.Then;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.api.ServiceRegistry;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.Persona;
 import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.PersonaManager;
-import uk.gov.homeoffice.digital.sas.cucumberjparesttestapi.TestApiRunner;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.testapi.TestApiRunner;
 
 /**
  * 

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ResourceHelperTest.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/api/ResourceHelperTest.java
@@ -1,0 +1,78 @@
+package uk.gov.homeoffice.digital.sas.cucumberjparest.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static uk.gov.homeoffice.digital.sas.cucumberjparest.api.ResourceHelper.ITEMS_SIZE_JSON_PATH;
+import static uk.gov.homeoffice.digital.sas.cucumberjparest.api.ResourceHelper.ITEM_ID_JSON_PATH;
+import static uk.gov.homeoffice.digital.sas.cucumberjparest.api.ResourceHelper.RESOURCE_MUST_BE_UNIQUE;
+
+import io.restassured.path.json.JsonPath;
+import java.text.MessageFormat;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.Persona;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.persona.PersonaManager;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceHelperTest {
+
+  public static final String FILTER = "name=\"Shift\"";
+  public static final Map<String, String> FILTER_MAP = Map.of("filter", FILTER);
+  public static final String RESOURCE_TYPE = "time-period-types";
+  public static final String SERVICE = "timecard";
+  public static final String PERSONA_NAME = "Trevor";
+  public static final String RESOURCE_ID = "resource-id";
+
+  private final Persona persona = new Persona();
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JpaRestApiClient jpaRestApiClient;
+
+  @Mock
+  private PersonaManager personaManager;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private JsonPath jsonPath;
+
+  private ResourceHelper resourceHelper;
+
+  @BeforeEach
+  void setup() {
+    resourceHelper = new ResourceHelper(jpaRestApiClient, personaManager);
+    Mockito.when(personaManager.getPersona(PERSONA_NAME)).thenReturn(persona);
+    Mockito.when(
+        jpaRestApiClient.retrieve(eq(persona), eq(SERVICE), eq(RESOURCE_TYPE), eq(FILTER_MAP))
+            .getResponse().getBody().jsonPath()).thenReturn(jsonPath);
+  }
+
+  @Test
+  void getResourceId_uniqueResource_resourceIdReturned() {
+    Mockito.when(jsonPath.get(ITEMS_SIZE_JSON_PATH)).thenReturn(1);
+    Mockito.when(jsonPath.get(ITEM_ID_JSON_PATH)).thenReturn(RESOURCE_ID);
+
+    String resourceId = resourceHelper.getResourceId(PERSONA_NAME, SERVICE, RESOURCE_TYPE, FILTER);
+
+    assertThat(resourceId).isEqualTo(RESOURCE_ID);
+  }
+
+  @Test
+  void getResourceId_noMatchingResource_featureIsFailed() {
+    Mockito.when(jsonPath.get(ITEMS_SIZE_JSON_PATH)).thenReturn(0);
+
+    AssertionError thrown = assertThrows(
+        AssertionError.class,
+        () -> resourceHelper.getResourceId(PERSONA_NAME, SERVICE, RESOURCE_TYPE, FILTER),
+        "Expected getResourceId() to throw an exception, but it didn't"
+    );
+
+    assertThat(thrown.getMessage())
+        .isEqualTo(MessageFormat.format(RESOURCE_MUST_BE_UNIQUE, 0));
+  }
+}

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/stepdefinitions/PayloadManagerStep.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/scenarios/stepdefinitions/PayloadManagerStep.java
@@ -1,4 +1,4 @@
-package uk.gov.homeoffice.digital.sas.cucumberjparesttestapi.stepdefinitions;
+package uk.gov.homeoffice.digital.sas.cucumberjparest.scenarios.stepdefinitions;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/README.md
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/README.md
@@ -1,4 +1,4 @@
-# cucumberjparesttestapi
+# cucumberjparest.testapi
 
 This package exists to isolate code used to launch a
 test SpringBootApplication that uses the jparest package

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/TestApiRunner.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/TestApiRunner.java
@@ -1,4 +1,4 @@
-package uk.gov.homeoffice.digital.sas.cucumberjparesttestapi;
+package uk.gov.homeoffice.digital.sas.cucumberjparest.testapi;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/controllers/TestsController.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/controllers/TestsController.java
@@ -1,4 +1,4 @@
-package uk.gov.homeoffice.digital.sas.cucumberjparesttestapi.controllers;
+package uk.gov.homeoffice.digital.sas.cucumberjparest.testapi.controllers;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +13,7 @@ public class TestsController {
     
     @GetMapping("empty.html")
     public @ResponseBody ResponseEntity<String> getEmptyResponse() {
-        return new ResponseEntity<String>(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 }

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/models/Profile.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparest/testapi/models/Profile.java
@@ -1,4 +1,4 @@
-package uk.gov.homeoffice.digital.sas.cucumberjparesttestapi.models;
+package uk.gov.homeoffice.digital.sas.cucumberjparest.testapi.models;
 
 import java.util.Date;
 import java.util.HashMap;

--- a/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparesttestapi/stepdefinitions/PayloadManagerStep.java
+++ b/cucumber-jparest/src/test/java/uk/gov/homeoffice/digital/sas/cucumberjparesttestapi/stepdefinitions/PayloadManagerStep.java
@@ -1,0 +1,23 @@
+package uk.gov.homeoffice.digital.sas.cucumberjparesttestapi.stepdefinitions;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.cucumber.java.en.Then;
+import lombok.NonNull;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.api.PayloadManager;
+import uk.gov.homeoffice.digital.sas.cucumberjparest.api.PayloadManager.PayloadKey;
+
+public class PayloadManagerStep {
+
+  private final PayloadManager payloadManager;
+
+  public PayloadManagerStep(@NonNull PayloadManager payloadManager) {
+    this.payloadManager = payloadManager;
+  }
+
+  @Then("parse payload successfully")
+  public void parsePayloadSuccessfully() {
+    PayloadKey key = new PayloadKey("person-profiles", "valid");
+    assertThatNoException().isThrownBy(() -> this.payloadManager.getPayload(key));
+  }
+}

--- a/cucumber-jparest/src/test/resources/test/test.feature
+++ b/cucumber-jparest/src/test/resources/test/test.feature
@@ -1,0 +1,12 @@
+Feature: Test the test library
+
+  Scenario: Kebab case resource type should be allowed
+
+    If resource type is composed of more than one word, the convention is to use kebab-case.
+
+    Given the valid person-profiles are
+      """
+      {}
+      """
+    # The following step definition is only accessible to internal tests of cucumber-jparest
+    Then parse payload successfully

--- a/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/inlinePayloads.feature
+++ b/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/inlinePayloads.feature
@@ -47,3 +47,12 @@ Feature: Inline Payloads
     Then the last response should have a status code of 200
     When the tester creates the invalid profiles in the test service
     Then the last response should have a status code of 400
+
+  Scenario: Kebab case resource type should be allowed
+
+    If resource type is composed of more than one word, the convention is to use Kebab Case.
+
+    Given the valid person-profiles are
+      """
+      {}
+      """

--- a/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/inlinePayloads.feature
+++ b/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/inlinePayloads.feature
@@ -47,12 +47,3 @@ Feature: Inline Payloads
     Then the last response should have a status code of 200
     When the tester creates the invalid profiles in the test service
     Then the last response should have a status code of 400
-
-  Scenario: Kebab case resource type should be allowed
-
-    If resource type is composed of more than one word, the convention is to use kebab-case.
-
-    Given the valid person-profiles are
-      """
-      {}
-      """

--- a/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/inlinePayloads.feature
+++ b/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/inlinePayloads.feature
@@ -50,7 +50,7 @@ Feature: Inline Payloads
 
   Scenario: Kebab case resource type should be allowed
 
-    If resource type is composed of more than one word, the convention is to use Kebab Case.
+    If resource type is composed of more than one word, the convention is to use kebab-case.
 
     Given the valid person-profiles are
       """

--- a/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/interpolatedPayloads.feature
+++ b/cucumber-jparest/src/test/resources/uk/gov/homeoffice/digital/sas/cucumberjparest/interpolatedPayloads.feature
@@ -45,7 +45,6 @@ Feature: Interpolated payloads
     Then the 1st of the profiles in the last response should contain
       | field        | type    | expectation                                               |
       | bio          | String  | isNotNull()                                               |
-      | bio          | String  | isNotEqualTo("#{personaManager.getPersona('Trevor').id}") |
       | firstRelease | Instant | isNotNull()                                               |
 
   Scenario: Reference a persona in a file payload

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.0.12</version>
+		<version>0.0.13</version>
 	</parent>
 
 	<properties>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.0.11</version>
+		<version>0.0.12</version>
 	</parent>
 
 	<properties>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.11</version>
+        <version>0.0.12</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.12</version>
+        <version>0.0.13</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
     <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.version>0.0.12${snapshotSuffix}</project.version>
+        <project.version>0.0.13${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.0.11</version>
+    <version>0.0.12</version>
     <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.version>0.0.11${snapshotSuffix}</project.version>
+        <project.version>0.0.12${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Before this change, the following scenario setup (note the hyphen in the resource type string `time-entries`) wouldn't be matched in `ParameterTypes#payload()` method, resulting in the scenario failing.
`When Trevor creates the valid time-entries in the timecard service`
This is due to the regex used in `ParameterType` annotation of the above method supporting words with alphanumeric characters only