### PR TITLE
add sonar link to slack notification

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -130,3 +130,4 @@ steps:
         Repo: {{ repo.name }}
         Branch: <${DRONE_REPO_LINK}/commits/{{ build.branch }}|{{ build.branch }}>
         Author: {{ build.author }}
+        <https://sonarcloud.io/dashboard?id=callisto-jparest&branch={{ build.branch }}&resolved=false|SonarCloud Analysis Report>


### PR DESCRIPTION
This PR adds a link to the sonar scan within the slack notification
![image](https://user-images.githubusercontent.com/109532529/202673528-d8da2f6c-8f3d-4bd6-b240-962e45727d8b.png)
