### PR TITLE
Eahw 2364/fix db connection issues

### DIFF
--- a/cucumber-jparest/pom.xml
+++ b/cucumber-jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.0.13</version>
+		<version>0.0.14</version>
 	</parent>
 
 	<properties>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.0.13</version>
+        <version>0.0.14</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiController.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiController.java
@@ -233,13 +233,12 @@ public class ResourceApiController<T extends BaseEntity> {
     payload.setId(id);
     this.entityValidator.validateAndThrowIfErrorsExist(payload);
 
-    var orig = repository.findById(id).orElseThrow(() -> new ResourceNotFoundException(id));
-
-    validateResourceTenantId(tenantId, orig, id);
-
     var transactionDefinition = new DefaultTransactionDefinition();
     var transactionStatus = this.transactionManager.getTransaction(transactionDefinition);
+    T orig;
     try {
+      orig = repository.findById(id).orElseThrow(() -> new ResourceNotFoundException(id));
+      validateResourceTenantId(tenantId, orig, id);
       BeanUtils.copyProperties(payload, orig, EntityUtils.ID_FIELD_NAME);
       repository.saveAndFlush(orig);
       transactionManager.commit(transactionStatus);

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiController.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiController.java
@@ -233,17 +233,14 @@ public class ResourceApiController<T extends BaseEntity> {
     payload.setId(id);
     this.entityValidator.validateAndThrowIfErrorsExist(payload);
 
-    var transactionDefinition = new DefaultTransactionDefinition();
-    var transactionStatus =
-        this.transactionManager.getTransaction(transactionDefinition);
-
     var orig = repository.findById(id).orElseThrow(() -> new ResourceNotFoundException(id));
 
     validateResourceTenantId(tenantId, orig, id);
 
-    BeanUtils.copyProperties(payload, orig, EntityUtils.ID_FIELD_NAME);
-
+    var transactionDefinition = new DefaultTransactionDefinition();
+    var transactionStatus = this.transactionManager.getTransaction(transactionDefinition);
     try {
+      BeanUtils.copyProperties(payload, orig, EntityUtils.ID_FIELD_NAME);
       repository.saveAndFlush(orig);
       transactionManager.commit(transactionStatus);
     } catch (RuntimeException ex) {

--- a/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiController.java
+++ b/jparest/src/main/java/uk/gov/homeoffice/digital/sas/jparest/controller/ResourceApiController.java
@@ -164,8 +164,6 @@ public class ResourceApiController<T extends BaseEntity> {
     T r2 = readPayload(body);
     validateAndSetTenantIdPayloadMatch(tenantId, r2);
 
-    this.entityValidator.validateAndThrowIfErrorsExist(r2);
-
     if (Objects.nonNull(r2.getId())) {
       throw new IllegalArgumentException(
         "A resource id should not be provided when creating a new resource.");
@@ -176,6 +174,7 @@ public class ResourceApiController<T extends BaseEntity> {
         this.transactionManager.getTransaction(transactionDefinition);
     T result;
     try {
+      this.entityValidator.validateAndThrowIfErrorsExist(r2);
       result = repository.saveAndFlush(r2);
       transactionManager.commit(transactionStatus);
     } catch (RuntimeException ex) {
@@ -229,14 +228,13 @@ public class ResourceApiController<T extends BaseEntity> {
       throw new IllegalArgumentException(
         "The supplied payload resource id value must match the url id path parameter value");
     }
-
-    payload.setId(id);
-    this.entityValidator.validateAndThrowIfErrorsExist(payload);
+    payload.setId(id);    
 
     var transactionDefinition = new DefaultTransactionDefinition();
     var transactionStatus = this.transactionManager.getTransaction(transactionDefinition);
     T orig;
     try {
+      this.entityValidator.validateAndThrowIfErrorsExist(payload);
       orig = repository.findById(id).orElseThrow(() -> new ResourceNotFoundException(id));
       validateResourceTenantId(tenantId, orig, id);
       BeanUtils.copyProperties(payload, orig, EntityUtils.ID_FIELD_NAME);

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.version>0.0.13${snapshotSuffix}</project.version>
+        <project.version>0.0.14${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.0.13</version>
+    <version>0.0.14</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Background:
This is to fix an issue found when running the QA test pack which eventually causes database locks and the timecard service becomes unresponsive. 

The QA test pack deletes records before it starts most of its tests, the same test pack can be run by another user simultaneously doing updates on the same user’s time entries. Eventually the test pack tries to update a time entry already deleted by the other user.

Problem found:
During the ResourceApiController Update method the transaction is started and then a bunch of validation is done against the entity. If the entity is not found an exception is raised. The exception is raised outside of the try/catch and a 404 returned back to the client, however the transaction that was started is never committed or rolled back, it is left hanging as “Idle in Transaction” in Postgres. 

Change to:
- move the start of the transaction to after the validation
- move the copyBean util into the try/catch in case that goes bang
- add a couple of tests to check whether a transaction is active for the update method when the validation fails and an exception is raised
- remove the Transactional annotation from the ResourceApiController Test class in order to add these two tests, as the transaction would always have been active with this specified

Note:
This is a quick fix with the understanding a wider refactor exercise to be undertaken at some point in the near future