### PR TITLE
Eahw 2576/kafka shared library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
-**/**/.flattened-pom.xml
+.flattened-pom.xml
 
 
 ### STS ###

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+**/**/.flattened-pom.xml
+
 
 ### STS ###
 .apt_generated

--- a/cucumber-jparest/pom.xml
+++ b/cucumber-jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.1.0</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>uk.gov.homeoffice.digital.sas</groupId>
 		<artifactId>parentpom</artifactId>
-		<version>0.1.0</version>
+		<version>${revision}</version>
 	</parent>
 
 	<properties>

--- a/jparest/pom.xml
+++ b/jparest/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>uk.gov.homeoffice.digital.sas</groupId>
         <artifactId>parentpom</artifactId>
-        <version>0.1.0</version>
+        <version>${revision}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/kafka-commons/pom.xml
+++ b/kafka-commons/pom.xml
@@ -23,17 +23,47 @@
       <artifactId>jakarta.validation-api</artifactId>
       <version>3.0.2</version>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
       <version>3.0.2</version>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
       <version>3.0.2</version>
     </dependency>
 
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.9.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.1.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>4.10.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.24.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/kafka-commons/pom.xml
+++ b/kafka-commons/pom.xml
@@ -48,9 +48,28 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
       <version>${spring.boot.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -80,6 +99,13 @@
       <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <version>2.1.214</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/kafka-commons/pom.xml
+++ b/kafka-commons/pom.xml
@@ -15,6 +15,8 @@
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spring.kafka.version>3.0.2</spring.kafka.version>
+    <spring.boot.version>3.0.2</spring.boot.version>
   </properties>
 
   <dependencies>
@@ -27,16 +29,30 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-      <version>3.0.2</version>
+      <version>${spring.kafka.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
-      <version>3.0.2</version>
+      <version>${spring.boot.version}</version>
     </dependency>
 
     <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <version>${spring.kafka.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/kafka-commons/pom.xml
+++ b/kafka-commons/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>uk.gov.homeoffice.digital.sas</groupId>
+    <artifactId>parentpom</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>kafka-commons</artifactId>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/kafka-commons/pom.xml
+++ b/kafka-commons/pom.xml
@@ -12,8 +12,7 @@
   <artifactId>kafka-commons</artifactId>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.kafka.version>3.0.2</spring.kafka.version>
     <spring.boot.version>3.0.2</spring.boot.version>

--- a/kafka-commons/pom.xml
+++ b/kafka-commons/pom.xml
@@ -66,4 +66,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M9</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
 </project>

--- a/kafka-commons/pom.xml
+++ b/kafka-commons/pom.xml
@@ -20,6 +20,7 @@
   </properties>
 
   <dependencies>
+
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>
@@ -99,6 +100,7 @@
       <version>3.24.2</version>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
@@ -1,0 +1,33 @@
+package uk.gov.homeoffice.digital.sas.kafka.listener;
+
+import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
+import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
+
+public abstract class KafkaEntityListener<T> {
+
+  protected KafkaProducerService<T> kafkaProducerService;
+
+  protected KafkaEntityListener(KafkaProducerService<T> kafkaProducerService) {
+    this.kafkaProducerService = kafkaProducerService;
+  }
+
+  public abstract String resolveMessageKey(T resource);
+
+  protected void sendKafkaMessageOnCreate(T resource) {
+    sendMessage(resource, KafkaAction.CREATE);
+  }
+
+  protected void sendKafkaMessageOnUpdate(T resource) {
+    sendMessage(resource, KafkaAction.UPDATE);
+  }
+
+  protected void sendKafkaMessageOnDelete(T resource) {
+    sendMessage(resource, KafkaAction.DELETE);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void sendMessage(T resource, KafkaAction action) {
+    kafkaProducerService.sendMessage(resolveMessageKey(resource),
+        (Class<T>) resource.getClass(), resource, action);
+  }
+}

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
@@ -1,5 +1,6 @@
 package uk.gov.homeoffice.digital.sas.kafka.listener;
 
+import jakarta.validation.constraints.NotNull;
 import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
 import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
 
@@ -25,9 +26,7 @@ public abstract class KafkaEntityListener<T> {
     sendMessage(resource, KafkaAction.DELETE);
   }
 
-  @SuppressWarnings("unchecked")
-  private void sendMessage(T resource, KafkaAction action) {
-    kafkaProducerService.sendMessage(resolveMessageKey(resource),
-        (Class<T>) resource.getClass(), resource, action);
+  private void sendMessage(@NotNull T resource, KafkaAction action) {
+    kafkaProducerService.sendMessage(resolveMessageKey(resource), resource, action);
   }
 }

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
@@ -5,7 +5,7 @@ import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
 
 public abstract class KafkaEntityListener<T> {
 
-  protected KafkaProducerService<T> kafkaProducerService;
+  private final KafkaProducerService<T> kafkaProducerService;
 
   protected KafkaEntityListener(KafkaProducerService<T> kafkaProducerService) {
     this.kafkaProducerService = kafkaProducerService;

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaAction.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaAction.java
@@ -1,0 +1,16 @@
+package uk.gov.homeoffice.digital.sas.kafka.message;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum KafkaAction {
+  CREATE("create"),
+  UPDATE("update"),
+  DELETE("delete");
+  private final String stringValue;
+
+  @Override
+  public String toString() {
+    return stringValue;
+  }
+}

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
@@ -1,0 +1,23 @@
+package uk.gov.homeoffice.digital.sas.kafka.message;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class KafkaEventMessage<T> {
+
+  private final String schema;
+
+  @NotNull
+  private final T resource;
+
+  @NotNull
+  private final KafkaAction action;
+
+  public KafkaEventMessage(String projectVersion, Class<T> resourceType, T resource,
+      KafkaAction action) {
+    this.schema = resourceType.getName() + ", " + projectVersion;
+    this.resource = resource;
+    this.action = action;
+  }
+}

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class KafkaEventMessage<T> {
 
-  public static final String SCHEMA_FORMAT ="%s, %s";
+  public static final String SCHEMA_FORMAT = "%s, %s";
 
   private final String schema;
 

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 @Getter
 public class KafkaEventMessage<T> {
 
+  public static final String SCHEMA_FORMAT ="%s, %s";
+
   private final String schema;
 
   @NotNull
@@ -16,7 +18,7 @@ public class KafkaEventMessage<T> {
 
   public KafkaEventMessage(String projectVersion, Class<T> resourceType, T resource,
       KafkaAction action) {
-    this.schema = resourceType.getName() + ", " + projectVersion;
+    this.schema = String.format(SCHEMA_FORMAT, resourceType.getName(), projectVersion);
     this.resource = resource;
     this.action = action;
   }

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerService.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerService.java
@@ -4,11 +4,11 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
 import uk.gov.homeoffice.digital.sas.kafka.message.KafkaEventMessage;
 
-@Component
+@Service
 @EnableAutoConfiguration
 public class KafkaProducerService<T> {
 
@@ -28,7 +28,7 @@ public class KafkaProducerService<T> {
   @SuppressWarnings("unchecked")
   public void sendMessage(@NotNull String messageKey, @NotNull T resource, KafkaAction action) {
     var kafkaEventMessage = new KafkaEventMessage<>(projectVersion,
-        (Class<T>)resource.getClass(), resource, action);
+        (Class<T>) resource.getClass(), resource, action);
     kafkaTemplate.send(topicName, messageKey, kafkaEventMessage);
   }
 }

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerService.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerService.java
@@ -1,5 +1,6 @@
 package uk.gov.homeoffice.digital.sas.kafka.producer;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -24,9 +25,10 @@ public class KafkaProducerService<T> {
     this.projectVersion = projectVersion;
   }
 
-  public void sendMessage(String messageKey, Class<T> resourceType,
-      T resource, KafkaAction action) {
-    var kafkaEventMessage = new KafkaEventMessage<>(projectVersion, resourceType, resource, action);
+  @SuppressWarnings("unchecked")
+  public void sendMessage(@NotNull String messageKey, @NotNull T resource, KafkaAction action) {
+    var kafkaEventMessage = new KafkaEventMessage<>(projectVersion,
+        (Class<T>)resource.getClass(), resource, action);
     kafkaTemplate.send(topicName, messageKey, kafkaEventMessage);
   }
 }

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerService.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerService.java
@@ -1,0 +1,32 @@
+package uk.gov.homeoffice.digital.sas.kafka.producer;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
+import uk.gov.homeoffice.digital.sas.kafka.message.KafkaEventMessage;
+
+@Component
+@EnableAutoConfiguration
+public class KafkaProducerService<T> {
+
+  private final KafkaTemplate<String, KafkaEventMessage<T>> kafkaTemplate;
+  private final String topicName;
+  private final String projectVersion;
+
+  public KafkaProducerService(
+      KafkaTemplate<String, KafkaEventMessage<T>> kafkaTemplate,
+      @Value("${spring.kafka.template.default-topic}") String topicName,
+      @Value("${projectVersion}") String projectVersion) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.topicName = topicName;
+    this.projectVersion = projectVersion;
+  }
+
+  public void sendMessage(String messageKey, Class<T> resourceType,
+      T resource, KafkaAction action) {
+    var kafkaEventMessage = new KafkaEventMessage<>(projectVersion, resourceType, resource, action);
+    kafkaTemplate.send(topicName, messageKey, kafkaEventMessage);
+  }
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/TestConfig.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/TestConfig.java
@@ -1,9 +1,13 @@
 package uk.gov.homeoffice.digital.sas;
 
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
-@ComponentScan(basePackages = "uk.gov.homeoffice.digital.sas.kafka")
+@ComponentScan
+@EntityScan("uk.gov.homeoffice.digital.sas.model")
+@EnableJpaRepositories("uk.gov.homeoffice.digital.sas.repository")
 public class TestConfig {
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/TestConfig.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/TestConfig.java
@@ -1,0 +1,9 @@
+package uk.gov.homeoffice.digital.sas;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = "uk.gov.homeoffice.digital.sas.kafka")
+public class TestConfig {
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/config/TestConfig.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/config/TestConfig.java
@@ -1,4 +1,4 @@
-package uk.gov.homeoffice.digital.sas;
+package uk.gov.homeoffice.digital.sas.config;
 
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
-@ComponentScan
+@ComponentScan("uk.gov.homeoffice.digital.sas.kafka")
 @EntityScan("uk.gov.homeoffice.digital.sas.model")
 @EnableJpaRepositories("uk.gov.homeoffice.digital.sas.repository")
 public class TestConfig {

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import java.util.logging.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +29,8 @@ import uk.gov.homeoffice.digital.sas.repository.ProfileRepository;
     }
 )
 class EmbeddedKafkaIntegrationTest {
+
+  private final static Logger LOGGER = Logger.getLogger(EmbeddedKafkaIntegrationTest.class.getName());
 
   private static final String PROFILE_ID = "profileId";
   private static final String PROFILE_NAME = "Original profile";
@@ -56,7 +58,7 @@ class EmbeddedKafkaIntegrationTest {
   }
 
   @Test
-  void shouldSendCreateMessageToTopicFromProducer() throws Exception{
+  void shouldSendCreateMessageToTopicFromProducer() throws Exception {
     // GIVEN
     kafkaProducerService.sendMessage(profile.getId(), profile, KafkaAction.CREATE);
 
@@ -72,6 +74,7 @@ class EmbeddedKafkaIntegrationTest {
   void shouldSendCreateMessageToTopicWhenProfileIsCreated() throws Exception {
     // GIVEN
     profileRepository.save(profile);
+    LOGGER.info("CREATE - Profile Created");
 
     // WHEN
     boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);
@@ -85,8 +88,10 @@ class EmbeddedKafkaIntegrationTest {
   void shouldSendUpdateMessageToTopicWhenProfileIsUpdated() throws Exception {
     // GIVEN
     profileRepository.save(profile);
+    LOGGER.info("UPDATE - Profile Created");
     profile.setName(UPDATED_PROFILE_NAME);
     profile = profileRepository.save(profile);
+    LOGGER.info("UPDATE - Profile Updated");
 
     // WHEN
     boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);
@@ -97,12 +102,13 @@ class EmbeddedKafkaIntegrationTest {
     assertThat(kafkaConsumer.getPayload()).isEqualTo(expectedUpdateMessagePayload);
   }
 
-  @Disabled("Currently failing on CI/CD")
   @Test
   void shouldSendDeleteMessageToTopicWhenProfileIsDeleted() throws Exception {
     // GIVEN
     profileRepository.save(profile);
+    LOGGER.info("DELETE - Profile Created");
     profileRepository.delete(profile);
+    LOGGER.info("DELETE - Profile Deleted");
 
     // WHEN
     boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
@@ -1,0 +1,63 @@
+package uk.gov.homeoffice.digital.sas.kafka;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import uk.gov.homeoffice.digital.sas.TestConfig;
+import uk.gov.homeoffice.digital.sas.kafka.consumer.KafkaConsumer;
+import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
+import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
+import uk.gov.homeoffice.digital.sas.model.Profile;
+
+@SpringBootTest(classes = TestConfig.class)
+@DirtiesContext
+@EmbeddedKafka(
+    partitions = 1,
+    brokerProperties = {
+        "listeners=PLAINTEXT://localhost:3333",
+        "port=3333"
+    }
+)
+class EmbeddedKafkaIntegrationTest {
+
+  private final static String PROFILE_ID = "profileId";
+  private String EXPECTED_READ_PAYLOAD;
+  private Profile profile;
+
+  @Value("${projectVersion}")
+  private String version;
+
+  @Autowired
+  private KafkaProducerService<Profile> kafkaProducerService;
+
+  @Autowired
+  private KafkaConsumer kafkaConsumer;
+
+  @BeforeEach
+  void setup() {
+    profile = new Profile(PROFILE_ID);
+    EXPECTED_READ_PAYLOAD = "{\"schema\":\"uk.gov.homeoffice.digital.sas.model.Profile, "
+        .concat(this.version)
+        .concat("\",\"resource\":{\"id\":\"")
+        .concat(profile.getId())
+        .concat("\"},\"action\":\"")
+        .concat(KafkaAction.CREATE.name())
+        .concat("\"}");
+  }
+
+  @Test
+  void shouldSendProfileToTopicFromProducer() throws Exception{
+    kafkaProducerService.sendMessage(profile.getId(), Profile.class, profile, KafkaAction.CREATE);
+
+    boolean messageConsumed = kafkaConsumer.getLatch().await(10, TimeUnit.SECONDS);
+    assertThat(messageConsumed).isTrue();
+    assertThat(kafkaConsumer.getPayload()).isEqualTo(EXPECTED_READ_PAYLOAD);
+  }
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -96,6 +97,7 @@ class EmbeddedKafkaIntegrationTest {
     assertThat(kafkaConsumer.getPayload()).isEqualTo(expectedUpdateMessagePayload);
   }
 
+  @Disabled("Currently failing on CI/CD")
   @Test
   void shouldSendDeleteMessageToTopicWhenProfileIsDeleted() throws Exception {
     // GIVEN

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
@@ -58,7 +58,7 @@ class EmbeddedKafkaIntegrationTest {
   @Test
   void shouldSendCreateMessageToTopicFromProducer() throws Exception{
     // GIVEN
-    kafkaProducerService.sendMessage(profile.getId(), Profile.class, profile, KafkaAction.CREATE);
+    kafkaProducerService.sendMessage(profile.getId(), profile, KafkaAction.CREATE);
 
     // WHEN
     boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
@@ -10,14 +10,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import uk.gov.homeoffice.digital.sas.TestConfig;
 import uk.gov.homeoffice.digital.sas.kafka.consumer.KafkaConsumer;
 import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
 import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
 import uk.gov.homeoffice.digital.sas.model.Profile;
+import uk.gov.homeoffice.digital.sas.repository.ProfileRepository;
 
 @SpringBootTest(classes = TestConfig.class)
-@DirtiesContext
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @EmbeddedKafka(
     partitions = 1,
     brokerProperties = {
@@ -27,8 +29,11 @@ import uk.gov.homeoffice.digital.sas.model.Profile;
 )
 class EmbeddedKafkaIntegrationTest {
 
-  private final static String PROFILE_ID = "profileId";
-  private String EXPECTED_READ_PAYLOAD;
+  private static final String PROFILE_ID = "profileId";
+  private static final String PROFILE_NAME = "Original profile";
+  private static final String UPDATED_PROFILE_NAME = "Updated profile";
+  private static final int CONSUMER_TIMEOUT = 10;
+  private String EXPECTED_CREATE_MESSAGE_PAYLOAD;
   private Profile profile;
 
   @Value("${projectVersion}")
@@ -40,24 +45,67 @@ class EmbeddedKafkaIntegrationTest {
   @Autowired
   private KafkaConsumer kafkaConsumer;
 
+  @Autowired
+  private ProfileRepository profileRepository;
+
   @BeforeEach
   void setup() {
-    profile = new Profile(PROFILE_ID);
-    EXPECTED_READ_PAYLOAD = "{\"schema\":\"uk.gov.homeoffice.digital.sas.model.Profile, "
-        .concat(this.version)
-        .concat("\",\"resource\":{\"id\":\"")
-        .concat(profile.getId())
-        .concat("\"},\"action\":\"")
-        .concat(KafkaAction.CREATE.name())
-        .concat("\"}");
+    profile = new Profile(PROFILE_ID, PROFILE_NAME);
+    EXPECTED_CREATE_MESSAGE_PAYLOAD = generatePayload(version, profile, KafkaAction.CREATE);
   }
 
   @Test
-  void shouldSendProfileToTopicFromProducer() throws Exception{
+  void shouldSendCreateMessageToTopicFromProducer() throws Exception{
     kafkaProducerService.sendMessage(profile.getId(), Profile.class, profile, KafkaAction.CREATE);
 
-    boolean messageConsumed = kafkaConsumer.getLatch().await(10, TimeUnit.SECONDS);
+    boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);
     assertThat(messageConsumed).isTrue();
-    assertThat(kafkaConsumer.getPayload()).isEqualTo(EXPECTED_READ_PAYLOAD);
+    assertThat(kafkaConsumer.getPayload()).isEqualTo(EXPECTED_CREATE_MESSAGE_PAYLOAD);
+  }
+
+  @Test
+  void shouldSendCreateMessageToTopicWhenProfileIsCreated() throws Exception {
+    profileRepository.save(profile);
+    boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);
+    assertThat(messageConsumed).isTrue();
+
+    assertThat(kafkaConsumer.getPayload()).isEqualTo(EXPECTED_CREATE_MESSAGE_PAYLOAD);
+  }
+
+  @Test
+  void shouldSendUpdateMessageToTopicWhenProfileIsUpdated() throws Exception {
+    profileRepository.save(profile);
+    profile.setName(UPDATED_PROFILE_NAME);
+    profile = profileRepository.save(profile);
+
+    boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);
+    assertThat(messageConsumed).isTrue();
+
+    String expectedUpdateMessagePayload = generatePayload(version, profile, KafkaAction.UPDATE);
+    assertThat(kafkaConsumer.getPayload()).isEqualTo(expectedUpdateMessagePayload);
+  }
+
+  @Test
+  void shouldSendDeleteMessageToTopicWhenProfileIsDeleted() throws Exception {
+    profileRepository.save(profile);
+    profileRepository.delete(profile);
+
+    boolean messageConsumed = kafkaConsumer.getLatch().await(CONSUMER_TIMEOUT, TimeUnit.SECONDS);
+    assertThat(messageConsumed).isTrue();
+
+    String expectedDeleteMessagePayload = generatePayload(version, profile, KafkaAction.DELETE);
+    assertThat(kafkaConsumer.getPayload()).isEqualTo(expectedDeleteMessagePayload);
+  }
+
+  private String generatePayload(String version, Profile profile, KafkaAction action) {
+    return "{\"schema\":\"uk.gov.homeoffice.digital.sas.model.Profile, "
+        .concat(version)
+        .concat("\",\"resource\":{\"id\":\"")
+        .concat(profile.getId())
+        .concat("\",\"name\":\"")
+        .concat(profile.getName())
+        .concat("\"},\"action\":\"")
+        .concat(action.name())
+        .concat("\"}");
   }
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
@@ -3,7 +3,6 @@ package uk.gov.homeoffice.digital.sas.kafka.consumer;
 import java.util.concurrent.CountDownLatch;
 import lombok.Getter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import java.util.logging.Logger;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -14,18 +13,20 @@ import org.springframework.stereotype.Component;
 @Getter
 public class KafkaConsumer {
 
-  private final static Logger LOGGER = Logger.getLogger(KafkaConsumer.class.getName());
-  private final CountDownLatch latch = new CountDownLatch(1);
+  private CountDownLatch latch = new CountDownLatch(1);
   private String payload;
 
   @KafkaListener(topics = "${spring.kafka.template.default-topic}")
   public void receive(ConsumerRecord<String, String> consumerRecord) {
-    payload = consumerRecord.value();
-    LOGGER.info("Payload received.. ");
-    LOGGER.info("Key: ");
-    LOGGER.info(consumerRecord.key());
-    LOGGER.info("Value: ");
-    LOGGER.info(consumerRecord.value());
-    latch.countDown();
+    if (latch != null) {
+      latch.countDown();
+      if (latch.getCount() == 0) {
+        payload = consumerRecord.value();
+      }
+    }
+  }
+
+  public void setExpectedNumberOfMessages(int expectedNumberOfMessages) {
+    latch = new CountDownLatch(expectedNumberOfMessages);
   }
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
@@ -3,6 +3,7 @@ package uk.gov.homeoffice.digital.sas.kafka.consumer;
 import java.util.concurrent.CountDownLatch;
 import lombok.Getter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import java.util.logging.Logger;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -12,12 +13,19 @@ import org.springframework.stereotype.Component;
 @Component
 @Getter
 public class KafkaConsumer {
+
+  private final static Logger LOGGER = Logger.getLogger(KafkaConsumer.class.getName());
   private final CountDownLatch latch = new CountDownLatch(1);
   private String payload;
 
   @KafkaListener(topics = "${spring.kafka.template.default-topic}")
   public void receive(ConsumerRecord<String, String> consumerRecord) {
     payload = consumerRecord.value();
+    LOGGER.info("Payload received.. ");
+    LOGGER.info("Key: ");
+    LOGGER.info(consumerRecord.key());
+    LOGGER.info("Value: ");
+    LOGGER.info(consumerRecord.value());
     latch.countDown();
   }
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
@@ -6,6 +6,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+/**
+ * Basic Kafka consumer used to validate messages written to topics in integration tests
+ */
 @Component
 @Getter
 public class KafkaConsumer {

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/consumer/KafkaConsumer.java
@@ -1,0 +1,20 @@
+package uk.gov.homeoffice.digital.sas.kafka.consumer;
+
+import java.util.concurrent.CountDownLatch;
+import lombok.Getter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class KafkaConsumer {
+  private final CountDownLatch latch = new CountDownLatch(1);
+  private String payload;
+
+  @KafkaListener(topics = "${spring.kafka.template.default-topic}")
+  public void receive(ConsumerRecord<String, String> consumerRecord) {
+    payload = consumerRecord.value();
+    latch.countDown();
+  }
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
@@ -41,7 +41,6 @@ class KafkaEntityListenerTest {
 
     Mockito.verify(kafkaProducerService)
         .sendMessage(PROFILE_ID,
-            Profile.class,
             profile,
             KafkaAction.CREATE);
   }
@@ -52,7 +51,6 @@ class KafkaEntityListenerTest {
 
     Mockito.verify(kafkaProducerService)
         .sendMessage(PROFILE_ID,
-            Profile.class,
             profile,
             KafkaAction.UPDATE);
   }
@@ -63,7 +61,6 @@ class KafkaEntityListenerTest {
 
     Mockito.verify(kafkaProducerService)
         .sendMessage(PROFILE_ID,
-            Profile.class,
             profile,
             KafkaAction.DELETE);
   }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
@@ -1,0 +1,70 @@
+package uk.gov.homeoffice.digital.sas.kafka.listener;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
+import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
+import uk.gov.homeoffice.digital.sas.model.Profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaEntityListenerTest {
+
+  private Profile profile;
+  private final static String PROFILE_ID ="profileId";
+
+  @Mock
+  private KafkaProducerService<Profile> kafkaProducerService;
+
+  ProfileKafkaEntityListener kafkaEntityListener;
+
+
+  @BeforeEach
+  void setup() {
+    profile = new Profile(PROFILE_ID);
+    kafkaEntityListener = new ProfileKafkaEntityListener(kafkaProducerService);
+  }
+
+  @Test
+  void resolveMessageKey_profileEntity_profileIdReturnedAsMessageKey() {
+    assertThat(kafkaEntityListener.resolveMessageKey(profile)).isEqualTo(PROFILE_ID);
+  }
+
+  @Test
+  void sendKafkaMessageOnCreate_profileEntity_sendMessageMethodInvokedAsExpected() {
+    kafkaEntityListener.sendKafkaMessageOnCreate(profile);
+
+    Mockito.verify(kafkaProducerService)
+        .sendMessage(PROFILE_ID,
+            Profile.class,
+            profile,
+            KafkaAction.CREATE);
+  }
+
+  @Test
+  void sendKafkaMessageOnUpdate_profileEntity_sendMessageMethodInvokedAsExpected() {
+    kafkaEntityListener.sendKafkaMessageOnUpdate(profile);
+
+    Mockito.verify(kafkaProducerService)
+        .sendMessage(PROFILE_ID,
+            Profile.class,
+            profile,
+            KafkaAction.UPDATE);
+  }
+
+  @Test
+  void sendKafkaMessageOnDelete_profileEntity_sendMessageMethodInvokedAsExpected() {
+    kafkaEntityListener.sendKafkaMessageOnDelete(profile);
+
+    Mockito.verify(kafkaProducerService)
+        .sendMessage(PROFILE_ID,
+            Profile.class,
+            profile,
+            KafkaAction.DELETE);
+  }
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
@@ -23,7 +23,6 @@ class KafkaEntityListenerTest {
 
   ProfileKafkaEntityListener kafkaEntityListener;
 
-
   @BeforeEach
   void setup() {
     profile = new Profile(PROFILE_ID);

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListenerTest.java
@@ -15,8 +15,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MockitoExtension.class)
 class KafkaEntityListenerTest {
 
+  private static final String PROFILE_ID = "profileId";
+  private static final String PROFILE_NAME = "profileX";
   private Profile profile;
-  private final static String PROFILE_ID ="profileId";
 
   @Mock
   private KafkaProducerService<Profile> kafkaProducerService;
@@ -25,7 +26,7 @@ class KafkaEntityListenerTest {
 
   @BeforeEach
   void setup() {
-    profile = new Profile(PROFILE_ID);
+    profile = new Profile(PROFILE_ID, PROFILE_NAME);
     kafkaEntityListener = new ProfileKafkaEntityListener(kafkaProducerService);
   }
 

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/ProfileKafkaEntityListener.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/ProfileKafkaEntityListener.java
@@ -1,5 +1,8 @@
 package uk.gov.homeoffice.digital.sas.kafka.listener;
 
+import jakarta.persistence.PostPersist;
+import jakarta.persistence.PostRemove;
+import jakarta.persistence.PostUpdate;
 import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
 import uk.gov.homeoffice.digital.sas.model.Profile;
 
@@ -12,5 +15,20 @@ public class ProfileKafkaEntityListener extends KafkaEntityListener<Profile> {
   @Override
   public String resolveMessageKey(Profile profile) {
     return profile.getId();
+  }
+
+  @PostPersist
+  void sendMessageOnCreate(Profile resource) {
+      super.sendKafkaMessageOnCreate(resource);
+  }
+
+  @PostUpdate
+  void sendMessageOnUpdate(Profile resource) {
+    super.sendKafkaMessageOnUpdate(resource);
+  }
+
+  @PostRemove
+  void sendMessageOnDelete(Profile resource) {
+    super.sendKafkaMessageOnDelete(resource);
   }
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/ProfileKafkaEntityListener.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/listener/ProfileKafkaEntityListener.java
@@ -1,0 +1,16 @@
+package uk.gov.homeoffice.digital.sas.kafka.listener;
+
+import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
+import uk.gov.homeoffice.digital.sas.model.Profile;
+
+public class ProfileKafkaEntityListener extends KafkaEntityListener<Profile> {
+
+  public  ProfileKafkaEntityListener(KafkaProducerService<Profile> kafkaProducerService){
+    super(kafkaProducerService);
+  }
+
+  @Override
+  public String resolveMessageKey(Profile profile) {
+    return profile.getId();
+  }
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -1,0 +1,64 @@
+package uk.gov.homeoffice.digital.sas.kafka.producer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
+import uk.gov.homeoffice.digital.sas.kafka.message.KafkaEventMessage;
+import uk.gov.homeoffice.digital.sas.model.Profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaProducerServiceTest {
+
+  private final static String TOPIC_NAME = "callisto-profile";
+  private final static String PROFILE_ID = "profileId";
+  private final static String SCHEMA_VERSION = "1.0.0";
+  private Profile profile;
+
+  @Captor
+  private ArgumentCaptor<String> topicArgument;
+  @Captor
+  private ArgumentCaptor<String> messageKeyArgument;
+  @Captor
+  private ArgumentCaptor<KafkaEventMessage<Profile>> messageArgument;
+
+  @Mock
+  private KafkaTemplate<String, KafkaEventMessage<Profile>> kafkaTemplate;
+
+  private KafkaProducerService<Profile> kafkaProducerService;
+
+  @BeforeEach
+  void setup() {
+    profile = new Profile(PROFILE_ID);
+    kafkaProducerService = new KafkaProducerService<>(kafkaTemplate, TOPIC_NAME, SCHEMA_VERSION);
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = KafkaAction.class, names = {"CREATE", "UPDATE", "DELETE"})
+  void sendMessage_actionOnResource_messageIsSentWithCorrectArguments(KafkaAction action) {
+
+    assertThatNoException().isThrownBy(() ->
+        kafkaProducerService.sendMessage(PROFILE_ID, Profile.class, profile, action));
+
+    Mockito.verify(kafkaTemplate)
+        .send(topicArgument.capture(), messageKeyArgument.capture(), messageArgument.capture());
+
+    assertThat(topicArgument.getValue()).isEqualTo(TOPIC_NAME);
+    assertThat(messageKeyArgument.getValue()).isEqualTo(profile.getId());
+    assertThat(messageArgument.getValue().getSchema()).isEqualTo(
+        Profile.class.getCanonicalName() + ", " + SCHEMA_VERSION);
+    assertThat(messageArgument.getValue().getResource()).isEqualTo(profile);
+    assertThat(messageArgument.getValue().getAction()).isEqualTo(action);
+  }
+
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.homeoffice.digital.sas.model.Profile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static uk.gov.homeoffice.digital.sas.kafka.message.KafkaEventMessage.SCHEMA_FORMAT;
 
 @ExtendWith(MockitoExtension.class)
 class KafkaProducerServiceTest {
@@ -56,9 +57,8 @@ class KafkaProducerServiceTest {
     assertThat(topicArgument.getValue()).isEqualTo(TOPIC_NAME);
     assertThat(messageKeyArgument.getValue()).isEqualTo(profile.getId());
     assertThat(messageArgument.getValue().getSchema()).isEqualTo(
-        Profile.class.getCanonicalName() + ", " + SCHEMA_VERSION);
+        String.format(SCHEMA_FORMAT, Profile.class.getCanonicalName(), SCHEMA_VERSION));
     assertThat(messageArgument.getValue().getResource()).isEqualTo(profile);
     assertThat(messageArgument.getValue().getAction()).isEqualTo(action);
   }
-
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -50,7 +50,7 @@ class KafkaProducerServiceTest {
   void sendMessage_actionOnResource_messageIsSentWithCorrectArguments(KafkaAction action) {
 
     assertThatNoException().isThrownBy(() ->
-        kafkaProducerService.sendMessage(PROFILE_ID, Profile.class, profile, action));
+        kafkaProducerService.sendMessage(PROFILE_ID, profile, action));
 
     Mockito.verify(kafkaTemplate)
         .send(topicArgument.capture(), messageKeyArgument.capture(), messageArgument.capture());

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -21,7 +21,7 @@ import static uk.gov.homeoffice.digital.sas.kafka.message.KafkaEventMessage.SCHE
 @ExtendWith(MockitoExtension.class)
 class KafkaProducerServiceTest {
 
-  private final static String TOPIC_NAME = "callisto-profile";
+  private final static String TOPIC_NAME = "callisto-profile-topic";
   private final static String PROFILE_ID = "profileId";
   private final static String SCHEMA_VERSION = "1.0.0";
   private Profile profile;

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -46,7 +46,7 @@ class KafkaProducerServiceTest {
   }
 
   @ParameterizedTest
-  @EnumSource(value = KafkaAction.class, names = {"CREATE", "UPDATE", "DELETE"})
+  @EnumSource(value = KafkaAction.class)
   void sendMessage_actionOnResource_messageIsSentWithCorrectArguments(KafkaAction action) {
 
     assertThatNoException().isThrownBy(() ->

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -23,6 +23,7 @@ class KafkaProducerServiceTest {
 
   private final static String TOPIC_NAME = "callisto-profile-topic";
   private final static String PROFILE_ID = "profileId";
+  private final static String PROFILE_NAME = "profileX";
   private final static String SCHEMA_VERSION = "1.0.0";
   private Profile profile;
 
@@ -40,7 +41,7 @@ class KafkaProducerServiceTest {
 
   @BeforeEach
   void setup() {
-    profile = new Profile(PROFILE_ID);
+    profile = new Profile(PROFILE_ID, PROFILE_NAME);
     kafkaProducerService = new KafkaProducerService<>(kafkaTemplate, TOPIC_NAME, SCHEMA_VERSION);
   }
 

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
@@ -1,0 +1,14 @@
+package uk.gov.homeoffice.digital.sas.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Profile {
+  private String id;
+}

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
@@ -1,14 +1,22 @@
 package uk.gov.homeoffice.digital.sas.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import uk.gov.homeoffice.digital.sas.kafka.listener.ProfileKafkaEntityListener;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
+@Entity(name = "profile")
+@EntityListeners(ProfileKafkaEntityListener.class)
 public class Profile {
+  @Id
   private String id;
+  private String name;
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/repository/ProfileRepository.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/repository/ProfileRepository.java
@@ -1,0 +1,9 @@
+package uk.gov.homeoffice.digital.sas.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.homeoffice.digital.sas.model.Profile;
+
+@Repository
+public interface ProfileRepository extends JpaRepository<Profile, String> {
+}

--- a/kafka-commons/src/test/resources/application.properties
+++ b/kafka-commons/src/test/resources/application.properties
@@ -6,3 +6,10 @@ spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.Strin
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.group-id=profile
+
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.sql.init.platform=h2

--- a/kafka-commons/src/test/resources/application.properties
+++ b/kafka-commons/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+projectVersion=1.0.0
+
+spring.kafka.bootstrap-servers=localhost:3333
+spring.kafka.template.default-topic=callisto-profile-topic
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.group-id=profile

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.1.1</revision>
+        <revision>0.1.2</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>${revision}${snapshotSuffix}</project.version>
         <snapshotSuffix/>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <revision>0.1.1</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>${revision}${snapshotSuffix}</project.version>
-        <snapshotSuffix></snapshotSuffix>
+        <snapshotSuffix/>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <java.version>17</java.version>
@@ -78,6 +78,32 @@
                     <configLocation>google_checks.xml</configLocation>
                     <suppressionsLocation>checkstyle_suppressions.xml</suppressionsLocation>
                 </configuration>
+            </plugin>
+            <plugin>
+                <!-- https://maven.apache.org/maven-ci-friendly.html#install-deploy -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.1.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.1.0</revision>
+        <revision>0.1.1</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>${revision}${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
@@ -52,6 +52,7 @@
         <module>jparest</module>
         <module>demo</module>
         <module>cucumber-jparest</module>
+        <module>kafka-commons</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,13 @@
 
     <groupId>uk.gov.homeoffice.digital.sas</groupId>
     <artifactId>parentpom</artifactId>
-    <version>0.1.0</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <properties>
+        <revision>0.1.0</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.version>0.1.0${snapshotSuffix}</project.version>
+        <project.version>${revision}${snapshotSuffix}</project.version>
         <snapshotSuffix></snapshotSuffix>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>


### PR DESCRIPTION
Create a new library for common components used to interact with Kafka topics.

Allow library version to be modified in only one place using maven revision and flattened POM: https://maven.apache.org/maven-ci-friendly.html#install-deploy 

Include integration test to ensure that JPA entity lifecycle events cause the corresponding messages to be sent to Kafka topic.

N.B.
This library was added as a submodule of existing JPA REST parent project, to leverage its underlying setup (e.g. CI/CD pipeline), and because it wasn't clear initially whether it would have any dependency on JPA REST capabilities. Now, it has become apparent that there is no such dependency; so, longer term, this library should be extracted into a standalone project: https://collaboration.homeoffice.gov.uk/jira/browse/EAHW-2637 