### PR TITLE
Add KafkaEventMessage default constructor

### DIFF
--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
@@ -1,20 +1,24 @@
 package uk.gov.homeoffice.digital.sas.kafka.message;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@EqualsAndHashCode
 public class KafkaEventMessage<T> {
 
   public static final String SCHEMA_FORMAT = "%s, %s";
 
-  private final String schema;
+  private String schema;
 
   @NotNull
-  private final T resource;
+  private T resource;
 
   @NotNull
-  private final KafkaAction action;
+  private KafkaAction action;
 
   public KafkaEventMessage(String projectVersion, Class<T> resourceType, T resource,
       KafkaAction action) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.1.2</revision>
+        <revision>0.1.3</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>${revision}${snapshotSuffix}</project.version>
         <snapshotSuffix/>


### PR DESCRIPTION
Add KafkaEventMessage default constructor required by Object Mapper for deserialisation. This is to fix broken test here: https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/callisto-person-restapi/221/2/3
Also add `equals` and `hashcode` methods to facilitate comparison