### PR TITLE
Revert 56 eahw 2577/add kafka message default constructor

### DIFF
--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/message/KafkaEventMessage.java
@@ -1,24 +1,20 @@
 package uk.gov.homeoffice.digital.sas.kafka.message;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@EqualsAndHashCode
 public class KafkaEventMessage<T> {
 
   public static final String SCHEMA_FORMAT = "%s, %s";
 
-  private String schema;
+  private final String schema;
 
   @NotNull
-  private T resource;
+  private final T resource;
 
   @NotNull
-  private KafkaAction action;
+  private final KafkaAction action;
 
   public KafkaEventMessage(String projectVersion, Class<T> resourceType, T resource,
       KafkaAction action) {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.1.2</revision>
+        <revision>0.1.4</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>${revision}${snapshotSuffix}</project.version>
         <snapshotSuffix/>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.1.3</revision>
+        <revision>0.1.2</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>${revision}${snapshotSuffix}</project.version>
         <snapshotSuffix/>


### PR DESCRIPTION
Reverts UKHomeOffice/callisto-jparest#56

No need for KafkaEventMessage to have NoArgConstructor and EqualsAndHash annotations anymore. tests can compare JSON trees instead of having to deserialise to objects to be able to compare 