### PR TITLE
Eahw 2578/update resolve message key

### DIFF
--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
@@ -4,7 +4,8 @@ import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreRemove;
 import jakarta.persistence.PreUpdate;
 import jakarta.validation.constraints.NotNull;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
 import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
 import uk.gov.homeoffice.digital.sas.kafka.message.Messageable;
 import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
@@ -39,9 +40,9 @@ public final class KafkaEntityListener<T extends Messageable> {
   }
 
   private void sendMessage(@NotNull T resource, KafkaAction action) {
-    BiConsumer<KafkaAction, String> sendMessageConsumer =
-        (KafkaAction actionArg, String messageKeyArg) -> kafkaProducerService.sendMessage(
-            messageKeyArg, resource, actionArg);
+    Consumer<String> sendMessageConsumer =
+        (String messageKeyArg) -> kafkaProducerService.sendMessage(
+            messageKeyArg, resource, action);
 
     kafkaDbTransactionSynchronizer.registerSynchronization(
         action, resource, sendMessageConsumer);

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
@@ -14,10 +14,10 @@ public final class KafkaEntityListener<T extends Messageable> {
 
   private final KafkaProducerService<T> kafkaProducerService;
 
-  private final KafkaDbTransactionSynchronizer kafkaDbTransactionSynchronizer;
+  private final KafkaDbTransactionSynchronizer<T> kafkaDbTransactionSynchronizer;
 
   public KafkaEntityListener(KafkaProducerService<T> kafkaProducerService,
-                             KafkaDbTransactionSynchronizer kafkaDbTransactionSynchronizer) {
+                             KafkaDbTransactionSynchronizer<T> kafkaDbTransactionSynchronizer) {
     this.kafkaProducerService = kafkaProducerService;
     this.kafkaDbTransactionSynchronizer = kafkaDbTransactionSynchronizer;
   }

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
@@ -5,7 +5,6 @@ import jakarta.persistence.PreRemove;
 import jakarta.persistence.PreUpdate;
 import jakarta.validation.constraints.NotNull;
 import java.util.function.Consumer;
-
 import uk.gov.homeoffice.digital.sas.kafka.message.KafkaAction;
 import uk.gov.homeoffice.digital.sas.kafka.message.Messageable;
 import uk.gov.homeoffice.digital.sas.kafka.producer.KafkaProducerService;
@@ -22,7 +21,6 @@ public final class KafkaEntityListener<T extends Messageable> {
     this.kafkaProducerService = kafkaProducerService;
     this.kafkaDbTransactionSynchronizer = kafkaDbTransactionSynchronizer;
   }
-
 
   @PrePersist
   private void sendKafkaMessageOnCreate(T resource) {

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/listener/KafkaEntityListener.java
@@ -44,6 +44,6 @@ public final class KafkaEntityListener<T extends Messageable> {
             messageKeyArg, resource, actionArg);
 
     kafkaDbTransactionSynchronizer.registerSynchronization(
-        action, resource.resolveMessageKey(), sendMessageConsumer);
+        action, resource, sendMessageConsumer);
   }
 }

--- a/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/transactionsync/KafkaDbTransactionSynchronizer.java
+++ b/kafka-commons/src/main/java/uk/gov/homeoffice/digital/sas/kafka/transactionsync/KafkaDbTransactionSynchronizer.java
@@ -5,7 +5,7 @@ import static uk.gov.homeoffice.digital.sas.kafka.constants.Constants.DATABASE_T
 import static uk.gov.homeoffice.digital.sas.kafka.constants.Constants.KAFKA_TRANSACTION_INITIALIZED;
 import static uk.gov.homeoffice.digital.sas.kafka.constants.Constants.TRANSACTION_SUCCESSFUL;
 
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +21,7 @@ public class KafkaDbTransactionSynchronizer<T extends Messageable> {
   private static final Logger log = LoggerFactory.getLogger(KafkaDbTransactionSynchronizer.class);
 
   public void registerSynchronization(KafkaAction action, T resource,
-                                      BiConsumer<KafkaAction, String> sendKafkaMessage) {
+                                      Consumer<String> sendKafkaMessage) {
 
     TransactionSynchronizationManager.registerSynchronization(
         new TransactionSynchronization() {
@@ -34,7 +34,7 @@ public class KafkaDbTransactionSynchronizer<T extends Messageable> {
             messageKey = resource.resolveMessageKey();
             log.info(String.format(KAFKA_TRANSACTION_INITIALIZED,
                 action, messageKey));
-            sendKafkaMessage.accept(action, messageKey);
+            sendKafkaMessage.accept(messageKey);
           }
 
           @Override

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/EmbeddedKafkaIntegrationTest.java
@@ -30,6 +30,7 @@ import uk.gov.homeoffice.digital.sas.repository.ProfileRepository;
 class EmbeddedKafkaIntegrationTest {
 
   private static final String PROFILE_ID = "profileId";
+  private static final String TENANT_ID = "tenantId";
   private static final String PROFILE_NAME = "Original profile";
   private static final String UPDATED_PROFILE_NAME = "Updated profile";
   private static final int CONSUMER_TIMEOUT = 10;
@@ -50,7 +51,7 @@ class EmbeddedKafkaIntegrationTest {
 
   @BeforeEach
   void setup() {
-    profile = new Profile(PROFILE_ID, PROFILE_NAME);
+    profile = new Profile(PROFILE_ID, TENANT_ID, PROFILE_NAME);
     EXPECTED_CREATE_MESSAGE_PAYLOAD = generateExpectedPayload(version, profile, KafkaAction.CREATE);
   }
 
@@ -120,6 +121,8 @@ class EmbeddedKafkaIntegrationTest {
         .concat(version)
         .concat("\",\"resource\":{\"id\":\"")
         .concat(profile.getId())
+        .concat("\",\"tenantId\":\"")
+        .concat(profile.getTenantId())
         .concat("\",\"name\":\"")
         .concat(profile.getName())
         .concat("\"},\"action\":\"")

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -37,6 +37,8 @@ class KafkaProducerServiceTest {
 
   private final static String TOPIC_NAME = "callisto-profile-topic";
   private final static String PROFILE_ID = "profileId";
+
+  private final static String TENANT_ID = "tenantId";
   private final static String PROFILE_NAME = "profileX";
   private final static String SCHEMA_VERSION = "1.0.0";
   private Profile profile;
@@ -57,7 +59,7 @@ class KafkaProducerServiceTest {
 
   @BeforeEach
   void setup() {
-    profile = new Profile(PROFILE_ID, PROFILE_NAME);
+    profile = new Profile(PROFILE_ID, TENANT_ID, PROFILE_NAME);
     kafkaProducerService = new KafkaProducerService<>(kafkaTemplate, TOPIC_NAME, SCHEMA_VERSION);
   }
 

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/kafka/producer/KafkaProducerServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -22,8 +23,6 @@ import uk.gov.homeoffice.digital.sas.model.Profile;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static uk.gov.homeoffice.digital.sas.kafka.constants.Constants.KAFKA_FAILED_MESSAGE;
 import static uk.gov.homeoffice.digital.sas.kafka.constants.Constants.KAFKA_SUCCESS_MESSAGE;
@@ -36,7 +35,7 @@ import java.util.concurrent.ExecutionException;
 class KafkaProducerServiceTest {
 
   private final static String TOPIC_NAME = "callisto-profile-topic";
-  private final static String PROFILE_ID = "profileId";
+  private final static Long PROFILE_ID = 1L;
 
   private final static String TENANT_ID = "tenantId";
   private final static String PROFILE_NAME = "profileX";
@@ -53,7 +52,12 @@ class KafkaProducerServiceTest {
   @Mock
   private KafkaTemplate<String, KafkaEventMessage<Profile>> kafkaTemplate;
 
-  private CompletableFuture<SendResult<String, KafkaEventMessage<Profile>>> responseFuture;
+  @Mock
+  private CompletableFuture<SendResult<String, KafkaEventMessage<Profile>>> responseFutureMock;
+  @Spy
+  private CompletableFuture<SendResult<String, KafkaEventMessage<Profile>>> responseFutureSpy;
+  @Mock
+  SendResult<String, KafkaEventMessage<Profile>> sendResult;
 
   private KafkaProducerService<Profile> kafkaProducerService;
 
@@ -66,19 +70,17 @@ class KafkaProducerServiceTest {
   @ParameterizedTest
   @EnumSource(value = KafkaAction.class)
   void sendMessage_actionOnResource_messageIsSentWithCorrectArguments(KafkaAction action) {
-    responseFuture = mock(CompletableFuture.class);
-
     when(kafkaTemplate.send(any(), any(), any()))
-        .thenReturn(responseFuture);
+        .thenReturn(responseFutureMock);
 
     assertThatNoException().isThrownBy(() ->
-        kafkaProducerService.sendMessage(PROFILE_ID, profile, action));
+        kafkaProducerService.sendMessage(PROFILE_ID.toString(), profile, action));
 
     Mockito.verify(kafkaTemplate)
         .send(topicArgument.capture(), messageKeyArgument.capture(), messageArgument.capture());
 
     assertThat(topicArgument.getValue()).isEqualTo(TOPIC_NAME);
-    assertThat(messageKeyArgument.getValue()).isEqualTo(profile.getId());
+    assertThat(messageKeyArgument.getValue()).isEqualTo(profile.getId().toString());
     assertThat(messageArgument.getValue().getSchema()).isEqualTo(
         String.format(SCHEMA_FORMAT, Profile.class.getCanonicalName(), SCHEMA_VERSION));
     assertThat(messageArgument.getValue().getResource()).isEqualTo(profile);
@@ -93,14 +95,12 @@ class KafkaProducerServiceTest {
 
     List<ILoggingEvent> logList = listAppender.list;
 
-    responseFuture = mock(CompletableFuture.class);
-
     when(kafkaTemplate.send(any(), any(), any()))
-        .thenReturn(responseFuture);
-    Mockito.doThrow(InterruptedException.class).when(responseFuture).get();
+        .thenReturn(responseFutureMock);
+    Mockito.doThrow(InterruptedException.class).when(responseFutureMock).get();
 
-    kafkaProducerService.sendMessage(PROFILE_ID, profile, action);
-    assertThat(responseFuture.isDone()).isFalse();
+    kafkaProducerService.sendMessage(PROFILE_ID.toString(), profile, action);
+    assertThat(responseFutureMock.isDone()).isFalse();
     assertThat(logList.get(0).getMessage()).isEqualTo(String.format(
         KAFKA_FAILED_MESSAGE,
         PROFILE_ID, "callisto-profile-topic",action.toString().toLowerCase()));
@@ -114,14 +114,12 @@ class KafkaProducerServiceTest {
 
     List<ILoggingEvent> logList = listAppender.list;
 
-    responseFuture = mock(CompletableFuture.class);
-
     when(kafkaTemplate.send(any(), any(), any()))
-        .thenReturn(responseFuture);
-    Mockito.doThrow(ExecutionException.class).when(responseFuture).get();
+        .thenReturn(responseFutureMock);
+    Mockito.doThrow(ExecutionException.class).when(responseFutureMock).get();
 
-    kafkaProducerService.sendMessage(PROFILE_ID, profile, action);
-    assertThat(responseFuture.isDone()).isFalse();
+    kafkaProducerService.sendMessage(PROFILE_ID.toString(), profile, action);
+    assertThat(responseFutureMock.isDone()).isFalse();
     assertThat(logList.get(0).getMessage()).isEqualTo(
         String.format(
             KAFKA_FAILED_MESSAGE,
@@ -131,19 +129,16 @@ class KafkaProducerServiceTest {
 
   @ParameterizedTest
   @EnumSource(value = KafkaAction.class)
-  void sendMessage_actionOnResource_onSuccessMessageLogged(KafkaAction action) throws InterruptedException, ExecutionException {
+  void sendMessage_actionOnResource_onSuccessMessageLogged(KafkaAction action) {
     ListAppender<ILoggingEvent> listAppender = getLoggingEventListAppender();
 
     List<ILoggingEvent> logList = listAppender.list;
 
-    responseFuture = spy(CompletableFuture.class);
-    SendResult<String, KafkaEventMessage<Profile>> sendResult = mock(SendResult.class);
+    when(kafkaTemplate.send(any(), any(), any())).thenReturn(responseFutureSpy);
+    when(responseFutureSpy.complete(sendResult)).thenReturn(true);
+    assertThat(responseFutureSpy.isDone()).isTrue();
 
-    when(kafkaTemplate.send(any(), any(), any())).thenReturn(responseFuture);
-    when(responseFuture.complete(sendResult)).thenReturn(true);
-    assertThat(responseFuture.isDone()).isTrue();
-
-    kafkaProducerService.sendMessage(PROFILE_ID, profile,
+    kafkaProducerService.sendMessage(PROFILE_ID.toString(), profile,
         action);
 
     assertThat(logList.get(0).getMessage()).isEqualTo(String.format(

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
@@ -2,14 +2,11 @@ package uk.gov.homeoffice.digital.sas.model;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.hibernate.annotations.GenericGenerator;
-import org.hibernate.annotations.Parameter;
 import uk.gov.homeoffice.digital.sas.kafka.listener.KafkaEntityListener;
 import uk.gov.homeoffice.digital.sas.kafka.message.Messageable;
 

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
@@ -2,6 +2,7 @@ package uk.gov.homeoffice.digital.sas.model;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,7 +20,8 @@ import uk.gov.homeoffice.digital.sas.kafka.message.Messageable;
 public class Profile implements Messageable {
 
   @Id
-  private String id;
+  @GeneratedValue
+  private Long id;
   private String tenantId;
   private String name;
 

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/model/Profile.java
@@ -2,11 +2,14 @@ package uk.gov.homeoffice.digital.sas.model;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
 import uk.gov.homeoffice.digital.sas.kafka.listener.KafkaEntityListener;
 import uk.gov.homeoffice.digital.sas.kafka.message.Messageable;
 
@@ -20,10 +23,11 @@ public class Profile implements Messageable {
 
   @Id
   private String id;
+  private String tenantId;
   private String name;
 
   @Override
   public String resolveMessageKey() {
-    return getId();
+    return getId() + ":" + getTenantId();
   }
 }

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/transactionsync/KafkaDbTransactionSynchronizerIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/transactionsync/KafkaDbTransactionSynchronizerIntegrationTest.java
@@ -35,8 +35,11 @@ import uk.gov.homeoffice.digital.sas.repository.ProfileRepository;
 )
 class KafkaDbTransactionSynchronizerIntegrationTest {
   private Long profileId;
+  private Long tenantId;
   private static final String PROFILE_NAME = "Original profile";
   private Profile profile;
+
+  private String messageKey;
 
   @Autowired
   private ProfileRepository profileRepository;
@@ -45,7 +48,8 @@ class KafkaDbTransactionSynchronizerIntegrationTest {
   void setup() {
     TransactionSynchronizationManager.initSynchronization();
     profileId = new Random().nextLong();
-    profile = new Profile(String.valueOf(profileId), PROFILE_NAME);
+    tenantId = new Random().nextLong();
+    profile = new Profile(String.valueOf(profileId), String.valueOf(tenantId), PROFILE_NAME);
   }
 
   @Test
@@ -56,13 +60,15 @@ class KafkaDbTransactionSynchronizerIntegrationTest {
 
     profileRepository.saveAndFlush(profile);
 
+    messageKey = profile.resolveMessageKey();
+
     assertThat(logList.get(0).getMessage()).isEqualTo(String.format(
         KAFKA_TRANSACTION_INITIALIZED,
-        KafkaAction.CREATE , profileId));
+        KafkaAction.CREATE , messageKey));
     assertThat(logList.get(1).getMessage()).isEqualTo(String.format(
         DATABASE_TRANSACTION_SUCCESSFUL, KafkaAction.CREATE));
     assertThat(logList.get(2).getMessage()).isEqualTo(String.format(
-        TRANSACTION_SUCCESSFUL, profileId));
+        TRANSACTION_SUCCESSFUL, messageKey));
 
   }
 
@@ -76,6 +82,8 @@ class KafkaDbTransactionSynchronizerIntegrationTest {
     profile.setName("updated_name");
     profileRepository.saveAndFlush(profile);
 
+    messageKey = profile.resolveMessageKey();
+
     List<ILoggingEvent> filteredList =
         logList.stream().filter(o -> o.getMessage().equals(
             String.format(
@@ -84,13 +92,13 @@ class KafkaDbTransactionSynchronizerIntegrationTest {
     assertThat(filteredList).hasSize(1);
 
     assertThat(logList.get(3).getMessage()).isEqualTo(String.format(
-        KAFKA_TRANSACTION_INITIALIZED, KafkaAction.UPDATE, profileId));
+        KAFKA_TRANSACTION_INITIALIZED, KafkaAction.UPDATE, messageKey));
 
     assertThat(logList.get(4).getMessage()).isEqualTo(String.format(
         DATABASE_TRANSACTION_SUCCESSFUL, KafkaAction.UPDATE));
 
     assertThat(logList.get(5).getMessage()).isEqualTo(String.format(
-        TRANSACTION_SUCCESSFUL, profileId));
+        TRANSACTION_SUCCESSFUL, messageKey));
   }
 
   @Test
@@ -103,6 +111,8 @@ class KafkaDbTransactionSynchronizerIntegrationTest {
 
     profileRepository.delete(profile);
 
+    messageKey = profile.resolveMessageKey();
+
     List<ILoggingEvent> filteredList =
         logList.stream().filter(o -> o.getMessage().equals(
             String.format(
@@ -111,13 +121,13 @@ class KafkaDbTransactionSynchronizerIntegrationTest {
     assertThat(filteredList).hasSize(1);
 
     assertThat(logList.get(3).getMessage() ).isEqualTo(String.format(
-        KAFKA_TRANSACTION_INITIALIZED, KafkaAction.DELETE, profileId));
+        KAFKA_TRANSACTION_INITIALIZED, KafkaAction.DELETE, messageKey));
 
     assertThat(logList.get(4).getMessage()).isEqualTo(String.format(
         DATABASE_TRANSACTION_SUCCESSFUL, KafkaAction.DELETE));
 
     assertThat(logList.get(5).getMessage()).isEqualTo(String.format(
-        TRANSACTION_SUCCESSFUL, profileId));
+        TRANSACTION_SUCCESSFUL, messageKey));
   }
 
   @AfterEach

--- a/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/transactionsync/KafkaDbTransactionSynchronizerIntegrationTest.java
+++ b/kafka-commons/src/test/java/uk/gov/homeoffice/digital/sas/transactionsync/KafkaDbTransactionSynchronizerIntegrationTest.java
@@ -34,8 +34,6 @@ import uk.gov.homeoffice.digital.sas.repository.ProfileRepository;
     }
 )
 class KafkaDbTransactionSynchronizerIntegrationTest {
-  private Long profileId;
-  private Long tenantId;
   private static final String PROFILE_NAME = "Original profile";
   private Profile profile;
 
@@ -47,9 +45,8 @@ class KafkaDbTransactionSynchronizerIntegrationTest {
   @BeforeEach
   void setup() {
     TransactionSynchronizationManager.initSynchronization();
-    profileId = new Random().nextLong();
-    tenantId = new Random().nextLong();
-    profile = new Profile(String.valueOf(profileId), String.valueOf(tenantId), PROFILE_NAME);
+    Long tenantId = new Random().nextLong();
+    profile = new Profile(null, String.valueOf(tenantId), PROFILE_NAME);
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>0.1.6</revision>
+        <revision>0.1.7</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.version>${revision}${snapshotSuffix}</project.version>
         <snapshotSuffix/>


### PR DESCRIPTION
This is minor change to the transaction sync work in kafka commons.
Person service is using the database Id as a part of the message key for kafka. 
This id is generated as part of the db transaction.
We needed to move this to a later stage of the transaction process so it was auto generated for usage.